### PR TITLE
chore: update license in package.json to GPL-3.0-or-later

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "version": "0.1.0",
-  "license": "MIT",
+  "license": "GPL-3.0-or-later",
   "author": "Mento Labs",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
### Description

We missed this when we updated the license in https://github.com/mento-protocol/mento-sdk/commit/27fc1cdc72c259118e2a75a4cd2a95b507a5b327
