### PR TITLE
refactor: move address type to its own file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "GPL-3.0-or-later",
   "author": "Mento Labs",
   "keywords": [

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,0 @@
-declare type Address = string

--- a/src/mento.ts
+++ b/src/mento.ts
@@ -11,6 +11,7 @@ import {
   getSymbolFromTokenAddress,
   increaseAllowance,
 } from './utils'
+import { Address } from './types'
 
 import { strict as assert } from 'assert'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type Address = string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 import { BigNumber, Contract, Signer, constants, providers } from 'ethers'
 
+import { Address } from './types'
+
 /**
  * Returns the broker address from the Celo registry
  * @param signerOrProvider an ethers provider or signer


### PR DESCRIPTION
### Description

This moves the defined `Address` type in `global.d.ts` to its own file since it's not being included in the npm package and we didn't want to spend too much time looking into to make these global types available.
