### PR TITLE
chore: bump to 0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,57 +2,72 @@
 
 The official Mento Protocol SDK for interacting with Multi-Collateral Mento smart contracts on the Celo network.
 
-# Sample Usage
+# Example Usage
 
 ```javascript
-const provider = new providers.JsonRpcProvider(
-  'https://baklava-forno.celo-testnet.org'
-)
-const pKey = 'privateKey'
-const wallet = new Wallet(pKey, provider)
+import { Wallet, providers, utils } from 'ethers'
 
-const mento = await Mento.create(wallet)
+import { Mento } from '@mento-protocol/mento-sdk'
 
-console.log('available pairs: ', await mento.getTradeablePairs())
-/*
+async function main() {
+  const provider = new providers.JsonRpcProvider(
+    'https://baklava-forno.celo-testnet.org'
+  )
+  const pKey =
+    'b214fcf9673dc1a880f8041a8c8952c2dc7daff41fb64cf7715919df095c3fce'
+  const wallet = new Wallet(pKey, provider)
+
+  const mento = await Mento.create(wallet)
+  console.log('available pairs: ', await mento.getTradeablePairs())
+  /*
+          [
         [
-      [
-        {
-          address: '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-          symbol: 'cUSD'
-        },
-        {
-          address: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          symbol: 'CELO'
-        }
-      ],
-      ...
-    ]
-    */
+          {
+            address: '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
+            symbol: 'cUSD'
+          },
+          {
+            address: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
+            symbol: 'CELO'
+          }
+        ],
+        ...
+      ]
+      */
 
-// swap 1 CELO for cUSD
-const one = 1
-const tokenIn = '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8' // CELO
-const tokenOut = '0x62492A644A588FD904270BeD06ad52B9abfEA1aE' // cUSD
-const amountIn = utils.parseUnits(one.toString(), 18)
-const expectedAmountOut = await mento.getAmountOut(
-  tokenIn,
-  tokenOut,
-  utils.parseUnits(one.toString(), 18)
-)
-// 95% of the quote to allow some slippage
-const minAmountOut = expectedAmountOut.mul(95).div(100)
+  // swap 1 CELO for cUSD
+  const one = 1
+  const tokenIn = '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8' // CELO
+  const tokenOut = '0x62492A644A588FD904270BeD06ad52B9abfEA1aE' // cUSD
+  const amountIn = utils.parseUnits(one.toString(), 18)
+  const expectedAmountOut = await mento.getAmountOut(
+    tokenIn,
+    tokenOut,
+    utils.parseUnits(one.toString(), 18)
+  )
+  // 95% of the quote to allow some slippage
+  const minAmountOut = expectedAmountOut.mul(95).div(100)
 
-// allow the broker contract to spend CELO on behalf of the wallet
-const allowanceTxObj = await mento.increaseTradingAllowance(tokenIn, amountIn)
-const allowanceTx = await wallet.sendTransaction(allowanceTxObj)
-const allowanceReceipt = await allowanceTx.wait()
-console.log('increaseAllowance receipt', allowanceReceipt)
+  // allow the broker contract to spend CELO on behalf of the wallet
+  const allowanceTxObj = await mento.increaseTradingAllowance(tokenIn, amountIn)
+  const allowanceTx = await wallet.sendTransaction(allowanceTxObj)
+  const allowanceReceipt = await allowanceTx.wait()
+  console.log('increaseAllowance receipt', allowanceReceipt)
 
-// execute the swap
-const swapTxObj = await mento.swapIn(tokenIn, tokenOut, amountIn, minAmountOut)
-const swapTx = await wallet.sendTransaction(swapTxObj)
-const swapReceipt = await swapTx.wait()
+  // execute the swap
+  const swapTxObj = await mento.swapIn(
+    tokenIn,
+    tokenOut,
+    amountIn,
+    minAmountOut
+  )
+  const swapTx = await wallet.sendTransaction(swapTxObj)
+  const swapReceipt = await swapTx.wait()
 
-console.log('swapIn receipt', swapReceipt)
+  console.log('swapIn receipt', swapReceipt)
+}
+
+main()
+  .then(() => console.log('Done'))
+  .catch((e) => console.error('Error:', e))
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [


### PR DESCRIPTION
### Description

This bumps the current version to `0.1.3` to push a new version of the sdk including the changes made in https://github.com/mento-protocol/mento-sdk/pull/16

### Other changes

Updated the readme to include import statements for the dependencies to have a full working example.
