### PR TITLE
docs: improve parameter desc in getExchangeForTokens

### DIFF
--- a/src/mento.ts
+++ b/src/mento.ts
@@ -304,8 +304,8 @@ export class Mento {
 
   /**
    * Returns the Mento exchange (if any) for a given pair of tokens
-   * @param token0 the first token
-   * @param token1 the second token
+   * @param token0 the address of the first token
+   * @param token1 the address of the second token
    * @returns exchange
    */
   async getExchangeForTokens(


### PR DESCRIPTION
### Description

This just improves the description of the parameters in `getExchangeForTokens` to be a lit less redundant and to be explicit about the parameter type (address). This was brought up by @aaronmgdr [on discord](https://discord.com/channels/966739027782955068/1063035405097783366/1083478640970440714)