### PR TITLE
feat: Add ability to query limits and circuit breaker status

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ['14.x', '16.x']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        node: ['18.x']
+        os: [ubuntu-latest]
 
     steps:
       - name: Checkout repo

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@mento-protocol/mento-core-ts": "^0.1.0"
+    "@mento-protocol/mento-core-ts": "^0.1.1"
   },
   "peerDependencies": {
     "ethers": "^5.7"

--- a/scripts/tradingLimits.ts
+++ b/scripts/tradingLimits.ts
@@ -1,0 +1,25 @@
+import { Mento } from '../src/mento'
+import { providers } from 'ethers'
+
+async function main() {
+  const provider = new providers.JsonRpcProvider(
+    'https://baklava-forno.celo-testnet.org'
+  )
+  const mento = await Mento.create(provider)
+
+  const cUSDCeloExchange =
+    '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c'
+
+  const cfgs = await mento.getTradingLimitConfig(cUSDCeloExchange)
+  const state = await mento.getTradingLimitState(cUSDCeloExchange)
+  const limits = await mento.getTradingLimits(cUSDCeloExchange)
+
+  console.log('cfgs', cfgs)
+  console.log('state', state)
+  console.log('======')
+  console.log('limits', limits)
+}
+
+main()
+  .then(() => console.log('Done'))
+  .catch((e) => console.error('Error:', e))

--- a/src/limits.test.ts
+++ b/src/limits.test.ts
@@ -15,16 +15,6 @@ jest.mock('@mento-protocol/mento-core-ts', () => {
     },
   }
 })
-jest.mock('ethers', () => {
-  return {
-    constants: jest.requireActual('ethers').constants,
-    providers: jest.requireActual('ethers').providers,
-    Signer: jest.requireActual('ethers').Signer,
-    utils: jest.requireActual('ethers').utils,
-    Wallet: jest.requireActual('ethers').Wallet,
-    Contract: jest.fn(),
-  }
-})
 
 // ========== Mock data ==========
 const fakeLimitConfig = {
@@ -54,13 +44,9 @@ const mockBrokerFactory = {
 // @ts-ignore
 Broker__factory.connect.mockReturnValue(mockBrokerFactory)
 
-let provider: providers.JsonRpcProvider
+const provider = new providers.JsonRpcProvider()
 
 describe('Limits', () => {
-  beforeAll(() => {
-    provider = new providers.JsonRpcProvider()
-  })
-
   afterEach(async () => {
     jest.clearAllMocks()
   })
@@ -244,7 +230,7 @@ describe('Limits', () => {
         '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c'
       const cUsdAddr = '0x62492A644A588FD904270BeD06ad52B9abfEA1aE'
 
-      expect(await getLimitId(cUsdCeloExchangeId, cUsdAddr)).toEqual(
+      expect(getLimitId(cUsdCeloExchangeId, cUsdAddr)).toEqual(
         '0x3135b662c38265d0655177097d524e1f05b7dec807f767ec6850a332ed6dac82'
       )
 
@@ -252,7 +238,7 @@ describe('Limits', () => {
         '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c'
       const cEurAddr = '0xf9ecE301247aD2CE21894941830A2470f4E774ca'
 
-      expect(await getLimitId(cEurCeloExchangeId, cEurAddr)).toEqual(
+      expect(getLimitId(cEurCeloExchangeId, cEurAddr)).toEqual(
         '0xb73ffc6b5123de3c8e460490add65a3b1f9d05c605782f22c0d56d92edfeef46'
       )
 
@@ -260,7 +246,7 @@ describe('Limits', () => {
         '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae'
       const cRealAddr = '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1'
 
-      expect(await getLimitId(cRealCeloExchangeId, cRealAddr)).toEqual(
+      expect(getLimitId(cRealCeloExchangeId, cRealAddr)).toEqual(
         '0xed0528e42b9ecae538aab34bf98fd123334fc870663d64c1bb018c66859aad7f'
       )
     })

--- a/src/limits.test.ts
+++ b/src/limits.test.ts
@@ -1,0 +1,268 @@
+import {
+  getLimitId,
+  getLimits,
+  getLimitsConfig,
+  getLimitsState,
+} from './limits'
+
+import { Broker__factory } from '@mento-protocol/mento-core-ts'
+import { providers } from 'ethers'
+
+jest.mock('@mento-protocol/mento-core-ts', () => {
+  return {
+    Broker__factory: {
+      connect: jest.fn(),
+    },
+  }
+})
+jest.mock('ethers', () => {
+  return {
+    constants: jest.requireActual('ethers').constants,
+    providers: jest.requireActual('ethers').providers,
+    Signer: jest.requireActual('ethers').Signer,
+    utils: jest.requireActual('ethers').utils,
+    Wallet: jest.requireActual('ethers').Wallet,
+    Contract: jest.fn(),
+  }
+})
+
+// ========== Mock data ==========
+const fakeLimitConfig = {
+  timestep0: 300,
+  timestep1: 86400,
+  limit0: 100000,
+  limit1: 500000,
+  limitGlobal: 0,
+  flags: 3,
+}
+const fakeLimitState = {
+  lastUpdated0: 1681381868,
+  lastUpdated1: 1681375758,
+  netflow0: 15,
+  netflow1: 20,
+  netflowGlobal: 0,
+}
+const fakeExchangeId =
+  '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c'
+const fakeAsset = '0x62492A644A588FD904270BeD06ad52B9abfEA1aE'
+
+// ========== Mock contract factories ==========
+const mockBrokerFactory = {
+  tradingLimitsConfig: jest.fn(),
+  tradingLimitsState: jest.fn(),
+}
+// @ts-ignore
+Broker__factory.connect.mockReturnValue(mockBrokerFactory)
+
+let provider: providers.JsonRpcProvider
+
+describe('Limits', () => {
+  beforeAll(() => {
+    provider = new providers.JsonRpcProvider()
+  })
+
+  afterEach(async () => {
+    jest.clearAllMocks()
+  })
+
+  describe('getLimitsConfig', () => {
+    it('should return the limits config', async () => {
+      const broker = Broker__factory.connect('0xfakeBrokerAddr', provider)
+      mockBrokerFactory.tradingLimitsConfig.mockResolvedValue(fakeLimitConfig)
+
+      const cfg = await getLimitsConfig(broker, fakeExchangeId, fakeAsset)
+      expect(cfg).toEqual(fakeLimitConfig)
+    })
+  })
+
+  describe('getLimitsState', () => {
+    it('should return the current state if up to date', async () => {
+      const broker = Broker__factory.connect('0xfakeBrokerAddr', provider)
+
+      const nowEpoch = Math.floor(Date.now() / 1000)
+      const updatedState = {
+        ...fakeLimitState,
+        lastUpdated0: nowEpoch,
+        lastUpdated1: nowEpoch,
+      }
+
+      mockBrokerFactory.tradingLimitsConfig.mockResolvedValue(fakeLimitConfig)
+      mockBrokerFactory.tradingLimitsState.mockResolvedValue(updatedState)
+
+      const state = await getLimitsState(broker, fakeExchangeId, fakeAsset)
+      expect(state).toEqual(updatedState)
+    })
+
+    it('should refresh L0 if outdated', async () => {
+      const broker = Broker__factory.connect('0xfakeBrokerAddr', provider)
+
+      const nowEpoch = Math.floor(Date.now() / 1000)
+      const stateWithOutdatedL0 = {
+        ...fakeLimitState,
+        lastUpdated0: nowEpoch - fakeLimitConfig.timestep0 - 1,
+        lastUpdated1: nowEpoch,
+      }
+
+      mockBrokerFactory.tradingLimitsConfig.mockResolvedValue(fakeLimitConfig)
+      mockBrokerFactory.tradingLimitsState.mockResolvedValue(
+        stateWithOutdatedL0
+      )
+
+      const state = await getLimitsState(broker, fakeExchangeId, fakeAsset)
+      expect(state.netflow0).toEqual(0)
+      expect(state.lastUpdated0).toEqual(nowEpoch)
+    })
+
+    it('should refresh L1 if outdated', async () => {
+      const broker = Broker__factory.connect('0xfakeBrokerAddr', provider)
+
+      const nowEpoch = Math.floor(Date.now() / 1000)
+      const stateWithOutdatedL1 = {
+        ...fakeLimitState,
+        lastUpdated0: nowEpoch,
+        lastUpdated1: nowEpoch - fakeLimitConfig.timestep1 - 1,
+      }
+
+      mockBrokerFactory.tradingLimitsConfig.mockResolvedValue(fakeLimitConfig)
+      mockBrokerFactory.tradingLimitsState.mockResolvedValue(
+        stateWithOutdatedL1
+      )
+
+      const state = await getLimitsState(broker, fakeExchangeId, fakeAsset)
+      expect(state.netflow1).toEqual(0)
+      expect(state.lastUpdated1).toEqual(nowEpoch)
+    })
+  })
+
+  describe('getLimits', () => {
+    beforeEach(() => {
+      mockBrokerFactory.tradingLimitsConfig.mockResolvedValue(fakeLimitConfig)
+      mockBrokerFactory.tradingLimitsState.mockResolvedValue(fakeLimitState)
+    })
+
+    it('should return limits for both L0 and L1', async () => {
+      const broker = Broker__factory.connect('0xfakeBrokerAddr', provider)
+      const limits = await getLimits(broker, fakeExchangeId, fakeAsset)
+      expect(limits.length).toEqual(2)
+    })
+
+    it('should return the right remaining limits for L0 and L1', async () => {
+      const nowEpoch = Math.floor(Date.now() / 1000)
+      const cfg = {
+        ...fakeLimitConfig,
+        limit0: 100,
+        limit1: 1000,
+      }
+      const stateWithoutNetflow = {
+        ...fakeLimitState,
+        lastUpdated0: nowEpoch,
+        lastUpdated1: nowEpoch,
+        netflow0: 0,
+        netflow1: 0,
+      }
+
+      mockBrokerFactory.tradingLimitsConfig.mockResolvedValue(cfg)
+      mockBrokerFactory.tradingLimitsState.mockResolvedValue(
+        stateWithoutNetflow
+      )
+
+      const broker = Broker__factory.connect('0xfakeBrokerAddr', provider)
+      const limits = await getLimits(broker, fakeExchangeId, fakeAsset)
+      expect(limits.length).toEqual(2)
+
+      const [l0Limit, l1Limit] = limits
+      expect(l0Limit.maxIn).toEqual(100)
+      expect(l0Limit.maxOut).toEqual(100)
+      expect(l0Limit.until).toEqual(nowEpoch + cfg.timestep0)
+      expect(l1Limit.maxIn).toEqual(1000)
+      expect(l1Limit.maxOut).toEqual(1000)
+      expect(l1Limit.until).toEqual(nowEpoch + cfg.timestep1)
+
+      const stateWithPositiveflow = {
+        ...stateWithoutNetflow,
+        netflow0: 20,
+        netflow1: 200,
+      }
+      mockBrokerFactory.tradingLimitsState.mockResolvedValue(
+        stateWithPositiveflow
+      )
+      const limitsAfterPositiveFlow = await getLimits(
+        broker,
+        fakeExchangeId,
+        fakeAsset
+      )
+      expect(limits.length).toEqual(2)
+
+      const [l0LimitAfterPosFlow, l1LimitAfterPosFlow] = limitsAfterPositiveFlow
+      expect(l0LimitAfterPosFlow.maxIn).toEqual(80)
+      expect(l0LimitAfterPosFlow.maxOut).toEqual(120)
+      expect(l0LimitAfterPosFlow.until).toEqual(nowEpoch + cfg.timestep0)
+      expect(l1LimitAfterPosFlow.maxIn).toEqual(800)
+      expect(l1LimitAfterPosFlow.maxOut).toEqual(1200)
+      expect(l1LimitAfterPosFlow.until).toEqual(nowEpoch + cfg.timestep1)
+
+      const stateWithNegativeflow = {
+        ...stateWithoutNetflow,
+        netflow0: -20,
+        netflow1: -200,
+      }
+      mockBrokerFactory.tradingLimitsState.mockResolvedValue(
+        stateWithNegativeflow
+      )
+      const limitsAfterNegativeFlow = await getLimits(
+        broker,
+        fakeExchangeId,
+        fakeAsset
+      )
+      expect(limits.length).toEqual(2)
+
+      const [l0LimitAfterNegFlow, l1LimitAfterNegFlow] = limitsAfterNegativeFlow
+      expect(l0LimitAfterNegFlow.maxIn).toEqual(120)
+      expect(l0LimitAfterNegFlow.maxOut).toEqual(80)
+      expect(l0LimitAfterNegFlow.until).toEqual(nowEpoch + cfg.timestep0)
+      expect(l1LimitAfterNegFlow.maxIn).toEqual(1200)
+      expect(l1LimitAfterNegFlow.maxOut).toEqual(800)
+      expect(l1LimitAfterNegFlow.until).toEqual(nowEpoch + cfg.timestep1)
+    })
+
+    it('should return limit for LG if configured', async () => {
+      const cfgWithLG = {
+        ...fakeLimitConfig,
+        limitGlobal: 1000000,
+      }
+      mockBrokerFactory.tradingLimitsConfig.mockResolvedValue(cfgWithLG)
+
+      const broker = Broker__factory.connect('0xfakeBrokerAddr', provider)
+      const limits = await getLimits(broker, fakeExchangeId, fakeAsset)
+      expect(limits.length).toEqual(3)
+    })
+  })
+
+  describe('getLimitId', () => {
+    it('should return the correct limit id for the given exchange and token', async () => {
+      const cUsdCeloExchangeId =
+        '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c'
+      const cUsdAddr = '0x62492A644A588FD904270BeD06ad52B9abfEA1aE'
+
+      expect(await getLimitId(cUsdCeloExchangeId, cUsdAddr)).toEqual(
+        '0x3135b662c38265d0655177097d524e1f05b7dec807f767ec6850a332ed6dac82'
+      )
+
+      const cEurCeloExchangeId =
+        '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c'
+      const cEurAddr = '0xf9ecE301247aD2CE21894941830A2470f4E774ca'
+
+      expect(await getLimitId(cEurCeloExchangeId, cEurAddr)).toEqual(
+        '0xb73ffc6b5123de3c8e460490add65a3b1f9d05c605782f22c0d56d92edfeef46'
+      )
+
+      const cRealCeloExchangeId =
+        '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae'
+      const cRealAddr = '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1'
+
+      expect(await getLimitId(cRealCeloExchangeId, cRealAddr)).toEqual(
+        '0xed0528e42b9ecae538aab34bf98fd123334fc870663d64c1bb018c66859aad7f'
+      )
+    })
+  })
+})

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -1,0 +1,142 @@
+import {
+  Address,
+  TradingLimit,
+  TradingLimitsConfig,
+  TradingLimitsState,
+} from './types'
+
+import { Broker } from '@mento-protocol/mento-core-ts'
+import { assert } from 'console'
+import { utils } from 'ethers'
+
+/**
+ * Returns the limit configuration in the broker for the given exchange and asset
+ * @param broker an instance of the broker
+ * @param exchangeId the id of the exchange
+ * @param asset the address of the asset with the limit
+ * @returns the limit configuration
+ */
+export async function getLimitsConfig(
+  broker: Broker,
+  exchangeId: string,
+  asset: Address
+): Promise<TradingLimitsConfig> {
+  const limitId = getLimitId(exchangeId, asset)
+  const cfg = await broker.tradingLimitsConfig(limitId)
+
+  return {
+    timestep0: cfg['timestep0'],
+    timestep1: cfg['timestep1'],
+    limit0: cfg['limit0'],
+    limit1: cfg['limit1'],
+    limitGlobal: cfg['limitGlobal'],
+    flags: cfg['flags'],
+  }
+}
+
+/**
+ * Returns the limit state in the broker for the given exchange and asset
+ * @param broker an instance of the broker
+ * @param exchangeId the id of the exchange
+ * @param asset the address of the asset with the limit
+ * @returns the limit state
+ */
+export async function getLimitsState(
+  broker: Broker,
+  exchangeId: string,
+  asset: Address
+): Promise<TradingLimitsState> {
+  const limitId = getLimitId(exchangeId, asset)
+
+  const [cfg, state] = await Promise.all([
+    getLimitsConfig(broker, exchangeId, asset),
+    broker.tradingLimitsState(limitId),
+  ])
+
+  const isL0Enabled = cfg.timestep0 > 0
+  const isL1Enabled = cfg.timestep1 > 0
+
+  const nowEpoch = Math.floor(Date.now() / 1000)
+  const isL0Outdated =
+    isL0Enabled && nowEpoch > state['lastUpdated0'] + cfg.timestep0
+  const isL1Outdated =
+    isL1Enabled && nowEpoch > state['lastUpdated1'] + cfg.timestep1
+
+  return {
+    lastUpdated0: isL0Outdated ? nowEpoch : state['lastUpdated0'],
+    lastUpdated1: isL1Outdated ? nowEpoch : state['lastUpdated1'],
+    netflow0: isL0Outdated ? 0 : state['netflow0'],
+    netflow1: isL1Outdated ? 0 : state['netflow1'],
+    netflowGlobal: state['netflowGlobal'],
+  }
+}
+
+/**
+ * Returns a human-friendly representation of the limits for the given exchange and asset
+ * @param broker an instance of the broker
+ * @param exchangeId the id of the exchange
+ * @param asset the address of the asset with the limit
+ * @returns a list of TradingLimit objects
+ */
+export async function getLimits(
+  broker: Broker,
+  exchangeId: string,
+  asset: Address
+): Promise<TradingLimit[]> {
+  const [cfg, state] = await Promise.all([
+    getLimitsConfig(broker, exchangeId, asset),
+    getLimitsState(broker, exchangeId, asset),
+  ])
+
+  const limits: TradingLimit[] = []
+  if (cfg.limit0 > 0) {
+    limits.push({
+      asset: asset,
+      maxIn: cfg.limit0 - state.netflow0,
+      maxOut: cfg.limit0 + state.netflow0,
+      until: state.lastUpdated0 + cfg.timestep0,
+    })
+  }
+
+  if (cfg.limit1 > 0) {
+    limits.push({
+      asset: asset,
+      maxIn: cfg.limit1 - state.netflow1,
+      maxOut: cfg.limit1 + state.netflow1,
+      until: state.lastUpdated1 + cfg.timestep1,
+    })
+  }
+
+  if (cfg.limitGlobal > 0) {
+    const timestampIn2030 = 1893456000 // a far away timestamp
+    limits.push({
+      asset: asset,
+      maxIn: cfg.limitGlobal - state.netflowGlobal,
+      maxOut: cfg.limitGlobal + state.netflowGlobal,
+      until: timestampIn2030,
+    })
+  }
+
+  return limits
+}
+
+/**
+ * Returns the limit id for the given exchange and asset
+ * @param exchangeId the id of the exchange
+ * @param asset the address of the asset with the limit
+ * @returns the limit id
+ */
+export async function getLimitId(
+  exchangeId: string,
+  asset: Address
+): Promise<string> {
+  const assetBytes32 = utils.zeroPad(asset, 32)
+  const exchangeIdBytes = utils.arrayify(exchangeId)
+  const assetBytes = utils.arrayify(assetBytes32)
+  assert(
+    exchangeIdBytes.length === assetBytes.length,
+    'exchangeId and asset0 must be the same length'
+  )
+
+  return utils.hexlify(exchangeIdBytes.map((b, i) => b ^ assetBytes[i]))
+}

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -6,14 +6,14 @@ import {
 } from './types'
 
 import { Broker } from '@mento-protocol/mento-core-ts'
-import { assert } from 'console'
+import { strict as assert } from 'assert'
 import { utils } from 'ethers'
 
 /**
  * Returns the limit configuration in the broker for the given exchange and asset
  * @param broker an instance of the broker
  * @param exchangeId the id of the exchange
- * @param asset the address of the asset with the limit
+ * @param asset the address of the limited asset
  * @returns the limit configuration
  */
 export async function getLimitsConfig(
@@ -38,7 +38,7 @@ export async function getLimitsConfig(
  * Returns the limit state in the broker for the given exchange and asset
  * @param broker an instance of the broker
  * @param exchangeId the id of the exchange
- * @param asset the address of the asset with the limit
+ * @param asset the address of the limited asset
  * @returns the limit state
  */
 export async function getLimitsState(
@@ -126,10 +126,7 @@ export async function getLimits(
  * @param asset the address of the asset with the limit
  * @returns the limit id
  */
-export async function getLimitId(
-  exchangeId: string,
-  asset: Address
-): Promise<string> {
+export function getLimitId(exchangeId: string, asset: Address): string {
   const assetBytes32 = utils.zeroPad(asset, 32)
   const exchangeIdBytes = utils.arrayify(exchangeId)
   const assetBytes = utils.arrayify(assetBytes32)

--- a/src/mento.test.ts
+++ b/src/mento.test.ts
@@ -1,12 +1,21 @@
+import { Contract, Wallet, ethers, providers, utils } from 'ethers'
 import {
   IBroker__factory,
   IExchangeProvider__factory,
 } from '@mento-protocol/mento-core-ts'
-import { Contract, ethers, providers, utils, Wallet } from 'ethers'
 
 import { Mento } from './mento'
 
-jest.mock('@mento-protocol/mento-core-ts')
+jest.mock('@mento-protocol/mento-core-ts', () => {
+  return {
+    // IBroker: jest.fn(),
+    IBroker__factory: {
+      connect: jest.fn(),
+    },
+    // IExchangeProvider: jest.fn(),
+    IExchangeProvider__factory: jest.fn(),
+  }
+})
 jest.mock('ethers', () => {
   return {
     constants: jest.requireActual('ethers').constants,

--- a/src/mento.test.ts
+++ b/src/mento.test.ts
@@ -1,19 +1,28 @@
-import { Contract, Wallet, ethers, providers, utils } from 'ethers'
 import {
+  BiPoolManager__factory,
+  IBreakerBox__factory,
   IBroker__factory,
   IExchangeProvider__factory,
 } from '@mento-protocol/mento-core-ts'
+import { Contract, Wallet, constants, ethers, providers, utils } from 'ethers'
 
 import { Mento } from './mento'
 
 jest.mock('@mento-protocol/mento-core-ts', () => {
   return {
-    // IBroker: jest.fn(),
     IBroker__factory: {
       connect: jest.fn(),
     },
-    // IExchangeProvider: jest.fn(),
+    Broker__factory: {
+      connect: jest.fn(),
+    },
     IExchangeProvider__factory: jest.fn(),
+    BiPoolManager__factory: {
+      connect: jest.fn(),
+    },
+    IBreakerBox__factory: {
+      connect: jest.fn(),
+    },
   }
 })
 jest.mock('ethers', () => {
@@ -68,7 +77,7 @@ describe('Mento', () => {
     0
   )
 
-  // mock contract factories
+  // ========== Mock contract factories ==========
   const fakeBrokerAddr = 'fakeBrokerAddr'
   const mockBroker = {
     address: fakeBrokerAddr,
@@ -83,6 +92,20 @@ describe('Mento', () => {
       populateTransaction: jest.fn(),
     },
   }
+  const mockBiPoolManager = {
+    breakerBox: jest.fn(() => 'fakeBreakerBoxAddr'),
+    getPoolExchange: jest.fn(() => {
+      return {
+        config: {
+          referenceRateFeedID: 'fakeReferenceRateId',
+        },
+      }
+    }),
+  }
+  const mockBreakerBox = {
+    getRateFeedTradingMode: jest.fn(),
+  }
+
   // @ts-ignore
   IBroker__factory.connect.mockReturnValue(mockBroker)
   // @ts-ignore
@@ -94,8 +117,12 @@ describe('Mento', () => {
         ],
     }
   })
+  // @ts-ignore
+  BiPoolManager__factory.connect.mockReturnValue(mockBiPoolManager)
+  // @ts-ignore
+  IBreakerBox__factory.connect.mockReturnValue(mockBreakerBox)
 
-  // mock ethers Contracts
+  // ========== Mock ethers contracts ==========
   const celoRegistryAddress = '0x000000000000000000000000000000000000ce10'
   const fakeRegistryContract = {
     getAddressForString: jest.fn(() => fakeBrokerAddr),
@@ -439,6 +466,47 @@ describe('Mento', () => {
       await expect(
         testee.swapOut(tokenIn, tokenOut, oneInWei, oneInWei)
       ).rejects.toThrow(`No exchange found for ${tokenIn} and ${tokenOut}`)
+    })
+  })
+
+  describe('getExchangeById', () => {
+    it('should return the exchange with the given id', async () => {
+      const testee = await Mento.create(provider)
+      const celoUSDExchange = await testee.getExchangeById(
+        fakeCeloUSDExchange.exchangeId
+      )
+      const celoEURExchange = await testee.getExchangeById(
+        fakeCeloEURExchange.exchangeId
+      )
+
+      expect(celoUSDExchange.id).toEqual(fakeCeloUSDExchange.exchangeId)
+      expect(celoEURExchange.id).toEqual(fakeCeloEURExchange.exchangeId)
+    })
+
+    it('should throw if no exchange is found for the given id', async () => {
+      const testee = await Mento.create(provider)
+      await expect(
+        testee.getExchangeById('nonExistentExchangeId')
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('isTradingEnabled', () => {
+    it('should return true if the trading mode is 0', async () => {
+      const testee = await Mento.create(provider)
+
+      mockBreakerBox.getRateFeedTradingMode.mockReturnValueOnce(constants.Zero)
+      expect(
+        await testee.isTradingEnabled(fakeCeloUSDExchange.exchangeId)
+      ).toBe(true)
+    })
+    it('should return false if the trading mode is not 0', async () => {
+      const testee = await Mento.create(provider)
+
+      mockBreakerBox.getRateFeedTradingMode.mockReturnValueOnce(constants.One)
+      expect(
+        await testee.isTradingEnabled(fakeCeloUSDExchange.exchangeId)
+      ).toBe(false)
     })
   })
 })

--- a/src/mento.ts
+++ b/src/mento.ts
@@ -1,11 +1,20 @@
 import {
+  Address,
+  TradingLimit,
+  TradingLimitsConfig,
+  TradingLimitsState,
+  TradingMode,
+} from './types'
+import {
+  BiPoolManager__factory,
+  Broker__factory,
+  IBreakerBox__factory,
   IBroker,
   IBroker__factory,
   IExchangeProvider,
   IExchangeProvider__factory,
 } from '@mento-protocol/mento-core-ts'
-import { BigNumber, BigNumberish, providers, Signer } from 'ethers'
-import { Address } from './types'
+import { BigNumber, BigNumberish, Signer, providers } from 'ethers'
 import {
   getBrokerAddressFromRegistry,
   getSymbolFromTokenAddress,
@@ -13,6 +22,7 @@ import {
   validateSigner,
   validateSignerOrProvider,
 } from './utils'
+import { getLimits, getLimitsConfig, getLimitsState } from './limits'
 
 import { strict as assert } from 'assert'
 
@@ -325,5 +335,112 @@ export class Mento {
       `More than one exchange found for ${token0} and ${token1}`
     )
     return exchanges[0]
+  }
+
+  /**
+   * Returns the Mento exchange for a given exchange id
+   * @param exchangeId the id of the exchange
+   * @returns the exchange with the given id
+   */
+  async getExchangeById(exchangeId: string): Promise<Exchange> {
+    const exchanges = (await this.getExchanges()).filter(
+      (e) => e.id === exchangeId
+    )
+
+    if (exchanges.length === 0) {
+      throw Error(`No exchange found for id ${exchangeId}`)
+    }
+
+    assert(
+      exchanges.length === 1,
+      `More than one exchange found with id ${exchangeId}`
+    )
+    return exchanges[0]
+  }
+
+  /**
+   * Returns whether trading is enabled in the given mode for a given exchange id
+   * @param exchangeId the id of the exchange
+   * @param mode the trading mode
+   * @returns true if trading is enabled in the given mode, false otherwise
+   */
+  async isTradingEnabled(
+    exchangeId: string,
+    mode: TradingMode = TradingMode.BI_DIRECTIONAL
+  ): Promise<boolean> {
+    const exchange = await this.getExchangeById(exchangeId)
+    const biPoolManager = BiPoolManager__factory.connect(
+      exchange.providerAddr,
+      this.signerOrProvider
+    )
+
+    const [breakerBoxAddr, exchangeConfig] = await Promise.all([
+      biPoolManager.breakerBox(),
+      biPoolManager.getPoolExchange(exchangeId),
+    ])
+
+    const breakerBox = IBreakerBox__factory.connect(
+      breakerBoxAddr,
+      this.signerOrProvider
+    )
+    const currentMode = await breakerBox.getRateFeedTradingMode(
+      exchangeConfig.config.referenceRateFeedID
+    )
+
+    return currentMode.toNumber() == mode
+  }
+
+  /**
+   * Return the trading limits for a given exchange id. Each limit is an object with the following fields:
+   * asset: the address of the asset with the limit
+   * maxIn: the maximum amount of the asset that can be sold
+   * maxOut: the maximum amount of the asset that can be bought
+   * until: the timestamp until which the limit is valid
+   * @param exchangeId the id of the exchange
+   * @returns the list of trading limits
+   */
+  async getTradingLimits(exchangeId: string): Promise<TradingLimit[]> {
+    const exchange = await this.getExchangeById(exchangeId)
+    const broker = Broker__factory.connect(
+      this.broker.address,
+      this.signerOrProvider
+    )
+
+    const assetWithLimit = exchange.assets[0] // currently limits are configured only on asset0
+    return getLimits(broker, exchangeId, assetWithLimit)
+  }
+
+  /**
+   * Returns the trading limits configuration for a given exchange id
+   * @param exchangeId the id of the exchange
+   * @returns the trading limits configuration
+   */
+  async getTradingLimitConfig(
+    exchangeId: string
+  ): Promise<TradingLimitsConfig> {
+    const exchange = await this.getExchangeById(exchangeId)
+    const broker = Broker__factory.connect(
+      this.broker.address,
+      this.signerOrProvider
+    )
+
+    const assetWithLimit = exchange.assets[0] // currently limits are configured only on asset0
+    return getLimitsConfig(broker, exchangeId, assetWithLimit)
+  }
+
+  /**
+   * Returns the trading limits state for a given exchange id
+   * @param exchangeId the id of the exchange
+   * @returns the trading limits state
+   */
+  async getTradingLimitState(exchangeId: string): Promise<TradingLimitsState> {
+    const exchange = await this.getExchangeById(exchangeId)
+    const broker = Broker__factory.connect(
+      this.broker.address,
+      this.signerOrProvider
+    )
+
+    const assetWithLimit = exchange.assets[0] // currently limits are configured only on asset0
+    return getLimitsState(broker, exchangeId, assetWithLimit)
   }
 }

--- a/src/mento.ts
+++ b/src/mento.ts
@@ -364,10 +364,7 @@ export class Mento {
    * @param mode the trading mode
    * @returns true if trading is enabled in the given mode, false otherwise
    */
-  async isTradingEnabled(
-    exchangeId: string,
-    mode: TradingMode = TradingMode.BI_DIRECTIONAL
-  ): Promise<boolean> {
+  async isTradingEnabled(exchangeId: string): Promise<boolean> {
     const exchange = await this.getExchangeById(exchangeId)
     const biPoolManager = BiPoolManager__factory.connect(
       exchange.providerAddr,
@@ -387,7 +384,8 @@ export class Mento {
       exchangeConfig.config.referenceRateFeedID
     )
 
-    return currentMode.toNumber() == mode
+    const BI_DIRECTIONAL_TRADING_MODE = 0
+    return currentMode.toNumber() == BI_DIRECTIONAL_TRADING_MODE
   }
 
   /**

--- a/src/mento.ts
+++ b/src/mento.ts
@@ -3,7 +3,6 @@ import {
   TradingLimit,
   TradingLimitsConfig,
   TradingLimitsState,
-  TradingMode,
 } from './types'
 import {
   BiPoolManager__factory,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,5 @@
 export type Address = string
 
-export enum TradingMode {
-  BI_DIRECTIONAL = 0,
-}
-
 export interface TradingLimit {
   asset: Address
   maxIn: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,29 @@
 export type Address = string
+
+export enum TradingMode {
+  BI_DIRECTIONAL = 0,
+}
+
+export interface TradingLimit {
+  asset: Address
+  maxIn: number
+  maxOut: number
+  until: number
+}
+
+export interface TradingLimitsConfig {
+  timestep0: number
+  timestep1: number
+  limit0: number
+  limit1: number
+  limitGlobal: number
+  flags: number
+}
+
+export interface TradingLimitsState {
+  lastUpdated0: number
+  lastUpdated1: number
+  netflow0: number
+  netflow1: number
+  netflowGlobal: number
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2283,10 +2283,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mento-protocol/mento-core-ts@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@mento-protocol/mento-core-ts@npm:0.1.0"
-  checksum: e80de011d6099ddc30ddc3d89854f1fc1cb2773b59c0051954ddc931509613fe2178b8c6a3e1d4170118cc260cce2f46a17a11bfee5dbfc48effeace62a8e344
+"@mento-protocol/mento-core-ts@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@mento-protocol/mento-core-ts@npm:0.1.1"
+  checksum: 336df2ae8338bc23de39327f346f29f26b2be2d335aa8ca125291a9408ba0bfac3699b17920dc269eaa988c535b0ad7bf4332da2d2947983335023239ea6f1e3
   languageName: node
   linkType: hard
 
@@ -2296,7 +2296,7 @@ __metadata:
   dependencies:
     "@babel/preset-env": ^7.20.2
     "@babel/preset-typescript": ^7.18.6
-    "@mento-protocol/mento-core-ts": ^0.1.0
+    "@mento-protocol/mento-core-ts": ^0.1.1
     "@size-limit/preset-small-lib": ^8.1.0
     "@tsconfig/recommended": ^1.0.1
     "@types/jest": ^29.4.0


### PR DESCRIPTION
### Description

This adds methods for checking if trading is enabled for a given exchange (i.e. if the circuit breaker has tripped) and to get the current trading limits for a given exchangeId. 

Most of the PR is around limits. Calling `mento.getTradingLimits(exchangeId)` returns an array of  `TradingLimit` in the following format:

```
limits [
  {
    asset: '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
    maxIn: 100000,
    maxOut: 100000,
    until: 1681389283
  },
  {
    asset: '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
    maxIn: 499851,
    maxOut: 500149,
    until: 1681462158
  }
]
```

### Other changes

Bumped `mento-core-ts` to `0.1.1` to include types for some core contracts.

### Tested

Unit tested all the methods in `limits.ts` as well as the `isTradingEnabled` method in `mento.ts`. The limit related methods in `mento.ts` don't have tests. It was getting a bit messy as I was writing them and I didn't want to spend more time on this issue since it's already quite delayed. The methods there are mostly wrappers over what is already tested in `limits.ts` anyways, so I don't think this is a big issue. I'll create an issue to clean up some of the mocks later on and write tests for them. 

### Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/211

### Backwards compatibility

Yes, as only new methods are added

### Documentation

No docs written yet
