### PR TITLE
chore: bump to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [


### PR DESCRIPTION
### Description

This bumps the version to 0.1.5 to push a new release including the circuit breaker and trading limits changes that were merged in #27 
