### PR TITLE
feat: add function to retrieve contract addresses by chain id

### DIFF
--- a/src/contracts.json
+++ b/src/contracts.json
@@ -1,0 +1,26 @@
+{
+  "42220": {
+    "Airgrab": "",
+    "Emission": "",
+    "Factory": "",
+    "MentoGovernor": "",
+    "MentoToken": "",
+    "TimelockController": ""
+  },
+  "62320": {
+    "Airgrab": "",
+    "Emission": "",
+    "Factory": "",
+    "MentoGovernor": "",
+    "MentoToken": "",
+    "TimelockController": ""
+  },
+  "44787": {
+    "Airgrab": "",
+    "Emission": "",
+    "Factory": "",
+    "MentoGovernor": "",
+    "MentoToken": "",
+    "TimelockController": ""
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,3 +23,16 @@ export interface TradingLimitsState {
   netflow1: number
   netflowGlobal: number
 }
+
+export interface ContractAddressMap {
+  [chainId: string]: ContractAddresses
+}
+
+export interface ContractAddresses {
+  Airgrab: string
+  Emission: string
+  Factory: string
+  MentoGovernor: string
+  MentoToken: string
+  TimelockController: string
+}

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,9 +1,11 @@
 import { Contract, Wallet, constants, providers, utils } from 'ethers'
 import {
   getBrokerAddressFromRegistry,
+  getContractsByChainId,
   getSymbolFromTokenAddress,
   increaseAllowance,
 } from './utils'
+import contractAddresses from './contracts.json'
 
 jest.mock('ethers', () => {
   return {
@@ -89,6 +91,25 @@ describe('Utils', () => {
       expect(increaseAllowanceFn).toHaveBeenCalledTimes(1)
       expect(increaseAllowanceFn).toHaveBeenCalledWith('fakeSpender', ten)
       expect(tx).toEqual(fakePopulatedTxObj)
+    })
+  })
+
+  describe('getContractsByChainId', () => {
+    it('should return contract addresses for a valid chainId', () => {
+      const validChainId = 42220
+      const expectedContracts = contractAddresses[validChainId]
+
+      const contracts = getContractsByChainId(validChainId)
+
+      expect(contracts).toEqual(expectedContracts)
+    })
+
+    it('should throw an error for a non-existent chainId', () => {
+      const invalidChainId = 99999
+
+      expect(() => {
+        getContractsByChainId(invalidChainId)
+      }).toThrow(`No contracts found for chainId ${invalidChainId}`)
     })
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import { BigNumberish, constants, Contract, providers, Signer } from 'ethers'
 
-import { Address } from './types'
+import { Address, ContractAddresses, ContractAddressMap } from './types'
+import contractAddresses from './contracts.json'
 
 /**
  * Ensures that given signer is truly a a connected signer
@@ -103,4 +104,15 @@ export async function increaseAllowance(
   const contract = new Contract(tokenAddr, abi, signerOrProvider)
 
   return await contract.populateTransaction.increaseAllowance(spender, amount)
+}
+
+export function getContractsByChainId(chainId: number): ContractAddresses {
+  const addresses = contractAddresses as ContractAddressMap
+  const contracts = addresses[chainId]
+
+  if (!contracts) {
+    throw new Error(`No contracts found for chainId ${chainId}`)
+  }
+
+  return contracts
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "module": "es2020",
     "moduleResolution": "node",
-    "outDir": "./dist/esm"
+    "outDir": "./dist/esm",
+    "resolveJsonModule": true
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "outDir": "./dist/cjs"
+    "outDir": "./dist/cjs",
+    "resolveJsonModule": true
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
### Description

This PR adds a utility function to retrieve the contract addresses for the governance-related contracts.

### Other changes

- None

### Tested

- Added unit tests to verify functionality

### Related issues

- Fixes #31 

### Backwards compatibility

N/A

### Documentation

- None