### PR TITLE
feat: add testnet governance addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/src/contracts.json
+++ b/src/contracts.json
@@ -4,20 +4,23 @@
     "Emission": "",
     "MentoGovernor": "",
     "MentoToken": "",
-    "TimelockController": ""
+    "TimelockController": "",
+    "Locking": ""
   },
   "62320": {
-    "Airgrab": "",
-    "Emission": "",
-    "MentoGovernor": "",
-    "MentoToken": "",
-    "TimelockController": ""
+    "Airgrab": "0x349aa8910577A6fE16cA7b98b5A135d14CE4dF9f",
+    "Emission": "0xcd427DDB27D835E5353312e7897bb9ad35F0E214",
+    "MentoGovernor": "0x5dFE8CC7743C636a86bED8F8d0de982d502E22fC",
+    "MentoToken": "0xD2f4f160BAF7D88a7A9189b03D0B3AA6A5D9775B",
+    "TimelockController": "0xb5977b1d208ef35FAf97A9534Dd849c356F362C5",
+    "Locking": "0x831DAfC0912e1c2aBa2Da90668c0856d48a8C06b"
   },
   "44787": {
-    "Airgrab": "",
-    "Emission": "",
-    "MentoGovernor": "",
-    "MentoToken": "",
-    "TimelockController": ""
+    "Airgrab": "0x281fA47f59456fA04DF699539fA4b1F25e7769A3",
+    "Emission": "0x8D1267bFf3f8166AEB2B58217b74188d1fe326f3",
+    "MentoGovernor": "0x84382a356c1Dc6ada21997E64dc72e5a7AcF5826",
+    "MentoToken": "0x53De3F938c64baB8C621c8A3C5000b385afE2404",
+    "TimelockController": "0x2AFC4a1e7928Fb3bfC81076740d3142FF8B1DE05",
+    "Locking": "0x65a1271ce7B2ec8D564A4Bc752E13A36a46e81B8"
   }
 }

--- a/src/governance.test.ts
+++ b/src/governance.test.ts
@@ -30,6 +30,7 @@ describe('Governance', () => {
       MentoToken: '0x789',
       Emission: '0xabc',
       TimelockController: '0xdef',
+      Locking: '0xghi',
     }
     // @ts-ignore
     getContractsByChainId.mockReturnValue(mockContractAddresses)

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -17,7 +17,7 @@ export class Governance {
     // TODO: Remove use of TestChainClient in future this is only meant for testing
     if (arg instanceof ChainClient || arg instanceof TestChainClient) {
       this.chainClient = arg
-    } else if (arg instanceof Signer || arg instanceof providers.Provider) {
+    } else if (Signer.isSigner(arg) || providers.Provider.isProvider(arg)) {
       this.chainClient = new ChainClient(arg)
     } else {
       throw new Error('Invalid constructor argument')

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -25,6 +25,20 @@ export class Governance {
   }
 
   /**
+   * This function retrieves the MentoGovernor contract.
+   * @returns The MentoGovernor contract.
+   */
+  public async getGovernorContract(): Promise<MentoGovernor> {
+    const contracts = getContractsByChainId(await this.chainClient.getChainId())
+    const mentoGovernorAddress = contracts.MentoGovernor
+
+    return MentoGovernor__factory.connect(
+      mentoGovernorAddress,
+      await this.chainClient.getSigner()
+    )
+  }
+
+  /**
    * Generates a transaction that submits a proposal to be created to the Mento Governor contract using the specified values.
    * @param targets The addresses of the contracts to be called during proposal execution.
    * @param values The values to be passed to the calls to the target contracts.
@@ -151,19 +165,5 @@ export class Governance {
         'Targets, values, and calldatas must all have the same length'
       )
     }
-  }
-
-  /**
-   * This function retrieves the MentoGovernor contract.
-   * @returns The MentoGovernor contract.
-   */
-  private async getGovernorContract(): Promise<MentoGovernor> {
-    const contracts = getContractsByChainId(await this.chainClient.getChainId())
-    const mentoGovernorAddress = contracts.MentoGovernor
-
-    return MentoGovernor__factory.connect(
-      mentoGovernorAddress,
-      await this.chainClient.getSigner()
-    )
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 /* istanbul ignore file */
 
 export * from './mento'
+export * from './governance'
+export * from './utils'

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface ContractAddresses {
   MentoGovernor: string
   MentoToken: string
   TimelockController: string
+  Locking: string
 }
 
 export enum ProposalState {


### PR DESCRIPTION
### Description

- This PR adds the testnet addresses of the deployed governance contracts to the contracts json file.

### Other changes

- Added module exports for governance and utils to allow consumers to interact with governance.

### Tested

- Verified existing tests passed after change
- Verified governor contract can be retrieved using local package
- Verified governance contracts can be retrieved by chain id using local package

### Related issues

- Fixes #44 

### Backwards compatibility

- No breaking changes

### Documentation

- Added issue to create guide https://github.com/mento-protocol/docs/issues/50
