### PR TITLE
fix: extend trading limits functions to multiple assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "0.2.8",
+  "version": "1.0.0",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/src/interfaces/tradingLimitsConfig.ts
+++ b/src/interfaces/tradingLimitsConfig.ts
@@ -1,4 +1,7 @@
+import { Address } from './tradingLimit'
+
 export interface TradingLimitsConfig {
+  asset: Address
   timestep0: number
   timestep1: number
   limit0: number

--- a/src/interfaces/tradingLimitsState.ts
+++ b/src/interfaces/tradingLimitsState.ts
@@ -1,4 +1,7 @@
+import { Address } from './tradingLimit'
+
 export interface TradingLimitsState {
+  asset: Address
   lastUpdated0: number
   lastUpdated1: number
   netflow0: number

--- a/src/limits.test.ts
+++ b/src/limits.test.ts
@@ -249,7 +249,7 @@ describe('Limits', () => {
       )
 
       const broker = Broker__factory.connect('0xfakeBrokerAddr', provider)
-      let limits = await getLimits(broker, fakeExchangeId, fakeAsset)
+      const limits = await getLimits(broker, fakeExchangeId, fakeAsset)
       expect(limits.length).toEqual(3)
       expect(limits[0].maxIn).toEqual(5)
       expect(limits[1].maxIn).toEqual(5)

--- a/src/limits.test.ts
+++ b/src/limits.test.ts
@@ -17,7 +17,12 @@ jest.mock('@mento-protocol/mento-core-ts', () => {
 })
 
 // ========== Mock data ==========
+const fakeAsset = '0x62492A644A588FD904270BeD06ad52B9abfEA1aE'
+const fakeExchangeId =
+  '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c'
+
 const fakeLimitConfig = {
+  asset: fakeAsset,
   timestep0: 300,
   timestep1: 86400,
   limit0: 100000,
@@ -26,15 +31,13 @@ const fakeLimitConfig = {
   flags: 3,
 }
 const fakeLimitState = {
+  asset: fakeAsset,
   lastUpdated0: 1681381868,
   lastUpdated1: 1681375758,
   netflow0: 15,
   netflow1: 20,
   netflowGlobal: 0,
 }
-const fakeExchangeId =
-  '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c'
-const fakeAsset = '0x62492A644A588FD904270BeD06ad52B9abfEA1aE'
 
 // ========== Mock contract factories ==========
 const mockBrokerFactory = {
@@ -221,6 +224,51 @@ describe('Limits', () => {
       const broker = Broker__factory.connect('0xfakeBrokerAddr', provider)
       const limits = await getLimits(broker, fakeExchangeId, fakeAsset)
       expect(limits.length).toEqual(3)
+    })
+
+    it('should constrain smaller limits according to bigger ones', async () => {
+      const nowEpoch = Math.floor(Date.now() / 1000)
+      const cfg = {
+        ...fakeLimitConfig,
+        limit0: 100,
+        limit1: 1000,
+        limitGlobal: 10000,
+      }
+      const stateWithL1ConstrainingL0 = {
+        ...fakeLimitState,
+        lastUpdated0: nowEpoch,
+        lastUpdated1: nowEpoch,
+        netflow0: 25,
+        netflow1: 995,
+        netflowGlobal: 1020,
+      }
+
+      mockBrokerFactory.tradingLimitsConfig.mockResolvedValue(cfg)
+      mockBrokerFactory.tradingLimitsState.mockResolvedValue(
+        stateWithL1ConstrainingL0
+      )
+
+      const broker = Broker__factory.connect('0xfakeBrokerAddr', provider)
+      let limits = await getLimits(broker, fakeExchangeId, fakeAsset)
+      expect(limits.length).toEqual(3)
+      expect(limits[0].maxIn).toEqual(5)
+      expect(limits[1].maxIn).toEqual(5)
+      expect(limits[2].maxIn).toEqual(8980)
+
+      const stateWithLGMaxedOut = {
+        ...fakeLimitState,
+        lastUpdated0: nowEpoch,
+        lastUpdated1: nowEpoch,
+        netflow0: 25,
+        netflow1: 25,
+        netflowGlobal: cfg.limitGlobal,
+      }
+      mockBrokerFactory.tradingLimitsState.mockResolvedValue(
+        stateWithLGMaxedOut
+      )
+      const maxedOutLimits = await getLimits(broker, fakeExchangeId, fakeAsset)
+      expect(maxedOutLimits.length).toEqual(3)
+      expect(maxedOutLimits.every((limit) => limit.maxIn === 0)).toBe(true)
     })
   })
 

--- a/src/mento.ts
+++ b/src/mento.ts
@@ -443,7 +443,6 @@ export class Mento {
   async getTradingLimitState(
     exchangeId: string
   ): Promise<TradingLimitsState[]> {
-    const exchange = await this.getExchangeById(exchangeId)
     const broker = Broker__factory.connect(
       this.broker.address,
       this.signerOrProvider


### PR DESCRIPTION
### Description

When trading limit related functionality was introduced it was restricted to only `asset0` for each exchange, as at the time no exchange had limits configured on both assets. This is no longer the case since multiple exchanges have limits configured on both, so In such cases, the result of `mento.getTradingLimits()` is incorrect.

This PR does a few different things:

1. `getTradingLimits()` now returns the current limits on both assets
2. `getTradingLimitConfig()` and `getTradingLimitState()` now return an array of `TradingLimitsConfig` and `TradingLimitsState` with an additional `asset` field instead of a single config/state, containing the configs/states for all assets in the exchange.
3. A fix on the `getTradingLimits` where now the state of limits with a smaller timeframe is constrained by the state of larger ones. For example, if L1 has been maxed out or has a very small capacity left, L0 should reflect that as well. Similarly if LG was completely maxed out and had a remaining of 0, both L1 and L0 should also be set to 0.

### Tested

Wrote a few additional tests and tested this manually using `scripts/tradingLimits.ts` to fetch the config, state and limits of several exchanges, particularly CELO/eXOF as it's currently maxed out on the CELO side:

configs:
```
[
  {
    asset: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
    timestep0: 300,
    timestep1: 86400,
    limit0: 6560000,
    limit1: 32800000,
    limitGlobal: 196800000,
    flags: 7
  },
  {
    asset: '0x471EcE3750Da237f93B8E339c536989b8978a438',
    timestep0: 300,
    timestep1: 86400,
    limit0: 20000,
    limit1: 100000,
    limitGlobal: 600000,
    flags: 7
  }
]
```

state:
```
[
  {
    asset: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
    lastUpdated0: 1717651318,
    lastUpdated1: 1717651318,
    netflow0: 0,
    netflow1: 0,
    netflowGlobal: 6721731
  },
  {
    asset: '0x471EcE3750Da237f93B8E339c536989b8978a438',
    lastUpdated0: 1717651318,
    lastUpdated1: 1717651318,
    netflow0: 0,
    netflow1: 0,
    netflowGlobal: 600000
  }
]
```

limits (`0x471EcE3750Da237f93B8E339c536989b8978a438` is CELO):
```
 [
  {
    asset: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
    maxIn: 6560000,
    maxOut: 6560000,
    until: 1717651618
  },
  {
    asset: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
    maxIn: 32800000,
    maxOut: 32800000,
    until: 1717737718
  },
  {
    asset: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
    maxIn: 190078269,
    maxOut: 203521731,
    until: 1893456000
  },
  {
    asset: '0x471EcE3750Da237f93B8E339c536989b8978a438',
    maxIn: 0,
    maxOut: 20000,
    until: 1717651618
  },
  {
    asset: '0x471EcE3750Da237f93B8E339c536989b8978a438',
    maxIn: 0,
    maxOut: 100000,
    until: 1717737718
  },
  {
    asset: '0x471EcE3750Da237f93B8E339c536989b8978a438',
    maxIn: 0,
    maxOut: 1200000,
    until: 1893456000
  }
]
```

### Backwards compatibility

Because the changes to the signature of `getTradingLimitConfig` and `getTradingLimitState` these changes won't be backwards compatible and will require a major patch, so I have bumped the version of the package to `1.0.0`
