### PR TITLE
feat: update tradeable pairs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [
@@ -69,7 +69,7 @@
     "@typescript-eslint/parser": "^5.53.0",
     "eslint": "^8.34.0",
     "eslint-config-prettier": "^8.6.0",
-    "ethers": "^5.7.2",
+    "ethers": "^5.7",
     "husky": "^8.0.2",
     "jest": "^29.4.2",
     "prettier": "^2.8.4",

--- a/src/constants/tradablePairs.ts
+++ b/src/constants/tradablePairs.ts
@@ -2,4003 +2,5271 @@
 import { TradablePair } from '../mento'
 
 export const TRADABLE_PAIRS: Record<number, TradablePair[]> = {
-  '42220': [
+  "42220": [
     {
-      id: 'CELO-cUSD',
-      assets: [
+      "id": "CELO-cUSD",
+      "assets": [
         {
-          address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          symbol: 'CELO',
+          "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+          "symbol": "CELO"
         },
         {
-          address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-          symbol: 'cUSD',
-        },
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cEUR',
-      assets: [
+      "id": "CELO-cEUR",
+      "assets": [
         {
-          address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          symbol: 'CELO',
+          "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+          "symbol": "CELO"
         },
         {
-          address: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-          symbol: 'cEUR',
-        },
+          "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "symbol": "cEUR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cREAL',
-      assets: [
+      "id": "CELO-cREAL",
+      "assets": [
         {
-          address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          symbol: 'CELO',
+          "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+          "symbol": "CELO"
         },
         {
-          address: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-          symbol: 'cREAL',
-        },
+          "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+          "symbol": "cREAL"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae',
-          assets: [
-            '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+          "assets": [
+            "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-cREAL',
-      assets: [
+      "id": "USDC-cREAL",
+      "assets": [
         {
-          address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          symbol: 'USDC',
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
         },
         {
-          address: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-          symbol: 'cREAL',
-        },
+          "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+          "symbol": "cREAL"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58',
-          assets: [
-            '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-            '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
+          "assets": [
+            "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+            "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          ]
+        }
+      ]
     },
     {
-      id: 'axlUSDC-cEUR',
-      assets: [
+      "id": "axlUSDC-cEUR",
+      "assets": [
         {
-          address: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          symbol: 'axlUSDC',
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
         },
         {
-          address: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-          symbol: 'cEUR',
-        },
+          "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "symbol": "cEUR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          ]
+        }
+      ]
     },
     {
-      id: 'axlUSDC-cREAL',
-      assets: [
+      "id": "axlUSDC-cREAL",
+      "assets": [
         {
-          address: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          symbol: 'axlUSDC',
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
         },
         {
-          address: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-          symbol: 'cREAL',
-        },
+          "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+          "symbol": "cREAL"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df',
-          assets: [
-            '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-            '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df",
+          "assets": [
+            "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+            "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          ]
+        }
+      ]
     },
     {
-      id: 'axlEUROC-cEUR',
-      assets: [
+      "id": "axlEUROC-cEUR",
+      "assets": [
         {
-          address: '0x061cc5a2C863E0C1Cb404006D559dB18A34C762d',
-          symbol: 'axlEUROC',
+          "address": "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d",
+          "symbol": "axlEUROC"
         },
         {
-          address: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-          symbol: 'cEUR',
-        },
+          "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "symbol": "cEUR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0x061cc5a2C863E0C1Cb404006D559dB18A34C762d',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-eXOF',
-      assets: [
+      "id": "CELO-eXOF",
+      "assets": [
         {
-          address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          symbol: 'CELO',
+          "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+          "symbol": "CELO"
         },
         {
-          address: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
-          symbol: 'eXOF',
-        },
+          "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
-          assets: [
-            '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "assets": [
+            "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
+        }
+      ]
     },
     {
-      id: 'axlEUROC-eXOF',
-      assets: [
+      "id": "axlEUROC-eXOF",
+      "assets": [
         {
-          address: '0x061cc5a2C863E0C1Cb404006D559dB18A34C762d',
-          symbol: 'axlEUROC',
+          "address": "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d",
+          "symbol": "axlEUROC"
         },
         {
-          address: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
-          symbol: 'eXOF',
-        },
+          "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xcc68743c58a31c4ec3c56bca3d579409b4e2424e5f37e54a85f917b22af74e7c',
-          assets: [
-            '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
-            '0x061cc5a2C863E0C1Cb404006D559dB18A34C762d',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xcc68743c58a31c4ec3c56bca3d579409b4e2424e5f37e54a85f917b22af74e7c",
+          "assets": [
+            "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+            "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d"
+          ]
+        }
+      ]
     },
     {
-      id: 'cKES-cUSD',
-      assets: [
+      "id": "cKES-cUSD",
+      "assets": [
         {
-          address: '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          symbol: 'cKES',
+          "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+          "symbol": "cKES"
         },
         {
-          address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-          symbol: 'cUSD',
-        },
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-cEUR',
-      assets: [
+      "id": "USDC-cEUR",
+      "assets": [
         {
-          address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          symbol: 'USDC',
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
         },
         {
-          address: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-          symbol: 'cEUR',
-        },
+          "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "symbol": "cEUR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-cUSD',
-      assets: [
+      "id": "USDC-cUSD",
+      "assets": [
         {
-          address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          symbol: 'USDC',
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
         },
         {
-          address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-          symbol: 'cUSD',
-        },
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          ]
+        }
+      ]
     },
     {
-      id: 'axlUSDC-cUSD',
-      assets: [
+      "id": "axlUSDC-cUSD",
+      "assets": [
         {
-          address: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          symbol: 'axlUSDC',
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
         },
         {
-          address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-          symbol: 'cUSD',
-        },
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          ]
+        }
+      ]
     },
     {
-      id: 'USD₮-cUSD',
-      assets: [
+      "id": "USD₮-cUSD",
+      "assets": [
         {
-          address: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          symbol: 'USD₮',
+          "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+          "symbol": "USD₮"
         },
         {
-          address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-          symbol: 'cUSD',
-        },
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-cUSD',
-      assets: [
+      "id": "PUSO-cUSD",
+      "assets": [
         {
-          address: '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          symbol: 'PUSO',
+          "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+          "symbol": "PUSO"
         },
         {
-          address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-          symbol: 'cUSD',
-        },
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+          ]
+        }
+      ]
     },
     {
-      id: 'cCOP-cUSD',
-      assets: [
+      "id": "cCOP-cUSD",
+      "assets": [
         {
-          address: '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          symbol: 'cCOP',
+          "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+          "symbol": "cCOP"
         },
         {
-          address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-          symbol: 'cUSD',
-        },
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+          ]
+        }
+      ]
     },
     {
-      id: 'cGHS-cUSD',
-      assets: [
+      "id": "cGHS-cUSD",
+      "assets": [
         {
-          address: '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          symbol: 'cGHS',
+          "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+          "symbol": "cGHS"
         },
         {
-          address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-          symbol: 'cUSD',
-        },
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cKES',
-      assets: [
+      "id": "CELO-cKES",
+      "assets": [
         {
-          address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          symbol: 'CELO',
+          "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+          "symbol": "CELO"
         },
         {
-          address: '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          symbol: 'cKES',
-        },
+          "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-USDC',
-      assets: [
+      "id": "CELO-USDC",
+      "assets": [
         {
-          address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          symbol: 'CELO',
+          "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+          "symbol": "CELO"
         },
         {
-          address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          symbol: 'USDC',
-        },
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-axlUSDC',
-      assets: [
+      "id": "CELO-axlUSDC",
+      "assets": [
         {
-          address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          symbol: 'CELO',
+          "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+          "symbol": "CELO"
         },
         {
-          address: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          symbol: 'axlUSDC',
-        },
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-USD₮',
-      assets: [
+      "id": "CELO-USD₮",
+      "assets": [
         {
-          address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          symbol: 'CELO',
+          "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+          "symbol": "CELO"
         },
         {
-          address: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          symbol: 'USD₮',
-        },
+          "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+          "symbol": "USD₮"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-PUSO',
-      assets: [
+      "id": "CELO-PUSO",
+      "assets": [
         {
-          address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          symbol: 'CELO',
+          "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+          "symbol": "CELO"
         },
         {
-          address: '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          symbol: 'PUSO',
-        },
+          "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+          "symbol": "PUSO"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cCOP',
-      assets: [
+      "id": "CELO-cCOP",
+      "assets": [
         {
-          address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          symbol: 'CELO',
+          "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+          "symbol": "CELO"
         },
         {
-          address: '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          symbol: 'cCOP',
-        },
+          "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+          "symbol": "cCOP"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cGHS',
-      assets: [
+      "id": "CELO-cGHS",
+      "assets": [
         {
-          address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          symbol: 'CELO',
+          "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+          "symbol": "CELO"
         },
         {
-          address: '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          symbol: 'cGHS',
-        },
+          "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+          "symbol": "cGHS"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-axlEUROC',
-      assets: [
+      "id": "CELO-axlEUROC",
+      "assets": [
         {
-          address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          symbol: 'CELO',
+          "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+          "symbol": "CELO"
         },
         {
-          address: '0x061cc5a2C863E0C1Cb404006D559dB18A34C762d',
-          symbol: 'axlEUROC',
-        },
+          "address": "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d",
+          "symbol": "axlEUROC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0x061cc5a2C863E0C1Cb404006D559dB18A34C762d',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d"
+          ]
+        }
+      ]
     },
     {
-      id: 'cEUR-cUSD',
-      assets: [
+      "id": "cEUR-cUSD",
+      "assets": [
         {
-          address: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-          symbol: 'cEUR',
+          "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "symbol": "cEUR"
         },
         {
-          address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-          symbol: 'cUSD',
-        },
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
+        }
+      ]
     },
     {
-      id: 'cREAL-cUSD',
-      assets: [
+      "id": "cREAL-cUSD",
+      "assets": [
         {
-          address: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-          symbol: 'cREAL',
+          "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+          "symbol": "cREAL"
         },
         {
-          address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-          symbol: 'cUSD',
-        },
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae',
-          assets: [
-            '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+          "assets": [
+            "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
+        }
+      ]
     },
     {
-      id: 'cUSD-eXOF',
-      assets: [
+      "id": "cUSD-eXOF",
+      "assets": [
         {
-          address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-          symbol: 'cUSD',
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "cUSD"
         },
         {
-          address: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
-          symbol: 'eXOF',
-        },
+          "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
-          assets: [
-            '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "assets": [
+            "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
+        }
+      ]
     },
     {
-      id: 'cEUR-cREAL',
-      assets: [
+      "id": "cEUR-cREAL",
+      "assets": [
         {
-          address: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-          symbol: 'cEUR',
+          "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "symbol": "cEUR"
         },
         {
-          address: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-          symbol: 'cREAL',
-        },
+          "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+          "symbol": "cREAL"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae',
-          assets: [
-            '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+          "assets": [
+            "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
+        }
+      ]
     },
     {
-      id: 'cEUR-eXOF',
-      assets: [
+      "id": "cEUR-eXOF",
+      "assets": [
         {
-          address: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-          symbol: 'cEUR',
+          "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "symbol": "cEUR"
         },
         {
-          address: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
-          symbol: 'eXOF',
-        },
+          "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
-          assets: [
-            '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "assets": [
+            "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
+        }
+      ]
     },
     {
-      id: 'cREAL-eXOF',
-      assets: [
+      "id": "cREAL-eXOF",
+      "assets": [
         {
-          address: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-          symbol: 'cREAL',
+          "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+          "symbol": "cREAL"
         },
         {
-          address: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
-          symbol: 'eXOF',
-        },
+          "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae',
-          assets: [
-            '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+          "assets": [
+            "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
-          assets: [
-            '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',
-            '0x471EcE3750Da237f93B8E339c536989b8978a438',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "assets": [
+            "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+            "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-axlUSDC',
-      assets: [
+      "id": "USDC-axlUSDC",
+      "assets": [
         {
-          address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          symbol: 'USDC',
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
         },
         {
-          address: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          symbol: 'axlUSDC',
-        },
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58',
-          assets: [
-            '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-            '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
+          "assets": [
+            "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+            "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df',
-          assets: [
-            '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-            '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df",
+          "assets": [
+            "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+            "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-axlEUROC',
-      assets: [
+      "id": "USDC-axlEUROC",
+      "assets": [
         {
-          address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          symbol: 'USDC',
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
         },
         {
-          address: '0x061cc5a2C863E0C1Cb404006D559dB18A34C762d',
-          symbol: 'axlEUROC',
-        },
+          "address": "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d",
+          "symbol": "axlEUROC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0x061cc5a2C863E0C1Cb404006D559dB18A34C762d',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-cKES',
-      assets: [
+      "id": "USDC-cKES",
+      "assets": [
         {
-          address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          symbol: 'USDC',
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
         },
         {
-          address: '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          symbol: 'cKES',
-        },
+          "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-USD₮',
-      assets: [
+      "id": "USDC-USD₮",
+      "assets": [
         {
-          address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          symbol: 'USDC',
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
         },
         {
-          address: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          symbol: 'USD₮',
-        },
+          "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+          "symbol": "USD₮"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-USDC',
-      assets: [
+      "id": "PUSO-USDC",
+      "assets": [
         {
-          address: '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          symbol: 'PUSO',
+          "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+          "symbol": "PUSO"
         },
         {
-          address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          symbol: 'USDC',
-        },
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-cCOP',
-      assets: [
+      "id": "USDC-cCOP",
+      "assets": [
         {
-          address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          symbol: 'USDC',
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
         },
         {
-          address: '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          symbol: 'cCOP',
-        },
+          "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+          "symbol": "cCOP"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-cGHS',
-      assets: [
+      "id": "USDC-cGHS",
+      "assets": [
         {
-          address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          symbol: 'USDC',
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
         },
         {
-          address: '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          symbol: 'cGHS',
-        },
+          "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+          "symbol": "cGHS"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+          ]
+        }
+      ]
     },
     {
-      id: 'axlEUROC-axlUSDC',
-      assets: [
+      "id": "axlEUROC-axlUSDC",
+      "assets": [
         {
-          address: '0x061cc5a2C863E0C1Cb404006D559dB18A34C762d',
-          symbol: 'axlEUROC',
+          "address": "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d",
+          "symbol": "axlEUROC"
         },
         {
-          address: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          symbol: 'axlUSDC',
-        },
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48',
-          assets: [
-            '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-            '0x061cc5a2C863E0C1Cb404006D559dB18A34C762d',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48",
+          "assets": [
+            "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+            "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d"
+          ]
+        }
+      ]
     },
     {
-      id: 'axlUSDC-cKES',
-      assets: [
+      "id": "axlUSDC-cKES",
+      "assets": [
         {
-          address: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          symbol: 'axlUSDC',
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
         },
         {
-          address: '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          symbol: 'cKES',
-        },
+          "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+          ]
+        }
+      ]
     },
     {
-      id: 'USD₮-axlUSDC',
-      assets: [
+      "id": "USD₮-axlUSDC",
+      "assets": [
         {
-          address: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          symbol: 'USD₮',
+          "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+          "symbol": "USD₮"
         },
         {
-          address: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          symbol: 'axlUSDC',
-        },
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-axlUSDC',
-      assets: [
+      "id": "PUSO-axlUSDC",
+      "assets": [
         {
-          address: '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          symbol: 'PUSO',
+          "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+          "symbol": "PUSO"
         },
         {
-          address: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          symbol: 'axlUSDC',
-        },
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+          ]
+        }
+      ]
     },
     {
-      id: 'axlUSDC-cCOP',
-      assets: [
+      "id": "axlUSDC-cCOP",
+      "assets": [
         {
-          address: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          symbol: 'axlUSDC',
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
         },
         {
-          address: '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          symbol: 'cCOP',
-        },
+          "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+          "symbol": "cCOP"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+          ]
+        }
+      ]
     },
     {
-      id: 'axlUSDC-cGHS',
-      assets: [
+      "id": "axlUSDC-cGHS",
+      "assets": [
         {
-          address: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          symbol: 'axlUSDC',
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
         },
         {
-          address: '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          symbol: 'cGHS',
-        },
+          "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+          "symbol": "cGHS"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+          ]
+        }
+      ]
     },
     {
-      id: 'USD₮-cKES',
-      assets: [
+      "id": "USD₮-cKES",
+      "assets": [
         {
-          address: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          symbol: 'USD₮',
+          "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+          "symbol": "USD₮"
         },
         {
-          address: '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          symbol: 'cKES',
-        },
+          "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-cKES',
-      assets: [
+      "id": "PUSO-cKES",
+      "assets": [
         {
-          address: '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          symbol: 'PUSO',
+          "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+          "symbol": "PUSO"
         },
         {
-          address: '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          symbol: 'cKES',
-        },
+          "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+          ]
+        }
+      ]
     },
     {
-      id: 'cCOP-cKES',
-      assets: [
+      "id": "cCOP-cKES",
+      "assets": [
         {
-          address: '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          symbol: 'cCOP',
+          "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+          "symbol": "cCOP"
         },
         {
-          address: '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          symbol: 'cKES',
-        },
+          "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+          ]
+        }
+      ]
     },
     {
-      id: 'cGHS-cKES',
-      assets: [
+      "id": "cGHS-cKES",
+      "assets": [
         {
-          address: '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          symbol: 'cGHS',
+          "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+          "symbol": "cGHS"
         },
         {
-          address: '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          symbol: 'cKES',
-        },
+          "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-USD₮',
-      assets: [
+      "id": "PUSO-USD₮",
+      "assets": [
         {
-          address: '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          symbol: 'PUSO',
+          "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+          "symbol": "PUSO"
         },
         {
-          address: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          symbol: 'USD₮',
-        },
+          "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+          "symbol": "USD₮"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+          ]
+        }
+      ]
     },
     {
-      id: 'USD₮-cCOP',
-      assets: [
+      "id": "USD₮-cCOP",
+      "assets": [
         {
-          address: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          symbol: 'USD₮',
+          "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+          "symbol": "USD₮"
         },
         {
-          address: '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          symbol: 'cCOP',
-        },
+          "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+          "symbol": "cCOP"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+          ]
+        }
+      ]
     },
     {
-      id: 'USD₮-cGHS',
-      assets: [
+      "id": "USD₮-cGHS",
+      "assets": [
         {
-          address: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          symbol: 'USD₮',
+          "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+          "symbol": "USD₮"
         },
         {
-          address: '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          symbol: 'cGHS',
-        },
+          "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+          "symbol": "cGHS"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-cCOP',
-      assets: [
+      "id": "PUSO-cCOP",
+      "assets": [
         {
-          address: '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          symbol: 'PUSO',
+          "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+          "symbol": "PUSO"
         },
         {
-          address: '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          symbol: 'cCOP',
-        },
+          "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+          "symbol": "cCOP"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-cGHS',
-      assets: [
+      "id": "PUSO-cGHS",
+      "assets": [
         {
-          address: '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          symbol: 'PUSO',
+          "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+          "symbol": "PUSO"
         },
         {
-          address: '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          symbol: 'cGHS',
-        },
+          "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+          "symbol": "cGHS"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          ],
-        },
-      ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+          ]
+        }
+      ]
     },
     {
-      id: 'cCOP-cGHS',
-      assets: [
+      "id": "cCOP-cGHS",
+      "assets": [
         {
-          address: '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          symbol: 'cCOP',
+          "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+          "symbol": "cCOP"
         },
         {
-          address: '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          symbol: 'cGHS',
-        },
+          "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+          "symbol": "cGHS"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
-          ],
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+          ]
         },
         {
-          providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-            '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
-          ],
-        },
-      ],
-    },
+          "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+            "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+          ]
+        }
+      ]
+    }
   ],
-  '44787': [
+  "44787": [
     {
-      id: 'CELO-cUSD',
-      assets: [
+      "id": "CELO-cUSD",
+      "assets": [
         {
-          address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          symbol: 'CELO',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-          symbol: 'cUSD',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cEUR',
-      assets: [
+      "id": "CELO-cEUR",
+      "assets": [
         {
-          address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          symbol: 'CELO',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-          symbol: 'cEUR',
-        },
+          "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+          "symbol": "cEUR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cREAL',
-      assets: [
+      "id": "CELO-cREAL",
+      "assets": [
         {
-          address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          symbol: 'CELO',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0xE4D517785D091D3c54818832dB6094bcc2744545',
-          symbol: 'cREAL',
-        },
+          "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+          "symbol": "cREAL"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae',
-          assets: [
-            '0xE4D517785D091D3c54818832dB6094bcc2744545',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+          "assets": [
+            "0xE4D517785D091D3c54818832dB6094bcc2744545",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-cREAL',
-      assets: [
+      "id": "USDC-cREAL",
+      "assets": [
         {
-          address: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          symbol: 'USDC',
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
         },
         {
-          address: '0xE4D517785D091D3c54818832dB6094bcc2744545',
-          symbol: 'cREAL',
-        },
+          "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+          "symbol": "cREAL"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58',
-          assets: [
-            '0xE4D517785D091D3c54818832dB6094bcc2744545',
-            '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
+          "assets": [
+            "0xE4D517785D091D3c54818832dB6094bcc2744545",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-cEUR',
-      assets: [
+      "id": "BridgedUSDC-cEUR",
+      "assets": [
         {
-          address: '0x87D61dA3d668797786D73BC674F053f87111570d',
-          symbol: 'BridgedUSDC',
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-          symbol: 'cEUR',
-        },
+          "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+          "symbol": "cEUR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0x87D61dA3d668797786D73BC674F053f87111570d',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-cREAL',
-      assets: [
+      "id": "BridgedUSDC-cREAL",
+      "assets": [
         {
-          address: '0x87D61dA3d668797786D73BC674F053f87111570d',
-          symbol: 'BridgedUSDC',
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0xE4D517785D091D3c54818832dB6094bcc2744545',
-          symbol: 'cREAL',
-        },
+          "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+          "symbol": "cREAL"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c',
-          assets: [
-            '0xE4D517785D091D3c54818832dB6094bcc2744545',
-            '0x87D61dA3d668797786D73BC674F053f87111570d',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
+          "assets": [
+            "0xE4D517785D091D3c54818832dB6094bcc2744545",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedEUROC-cEUR',
-      assets: [
+      "id": "BridgedEUROC-cEUR",
+      "assets": [
         {
-          address: '0x6e673502c5b55F3169657C004e5797fFE5be6653',
-          symbol: 'BridgedEUROC',
+          "address": "0x6e673502c5b55F3169657C004e5797fFE5be6653",
+          "symbol": "BridgedEUROC"
         },
         {
-          address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-          symbol: 'cEUR',
-        },
+          "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+          "symbol": "cEUR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0x6e673502c5b55F3169657C004e5797fFE5be6653',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0x6e673502c5b55F3169657C004e5797fFE5be6653"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-eXOF',
-      assets: [
+      "id": "CELO-eXOF",
+      "assets": [
         {
-          address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          symbol: 'CELO',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
-          symbol: 'eXOF',
-        },
+          "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
-          assets: [
-            '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "assets": [
+            "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedEUROC-eXOF',
-      assets: [
+      "id": "BridgedEUROC-eXOF",
+      "assets": [
         {
-          address: '0x6e673502c5b55F3169657C004e5797fFE5be6653',
-          symbol: 'BridgedEUROC',
+          "address": "0x6e673502c5b55F3169657C004e5797fFE5be6653",
+          "symbol": "BridgedEUROC"
         },
         {
-          address: '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
-          symbol: 'eXOF',
-        },
+          "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe',
-          assets: [
-            '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
-            '0x6e673502c5b55F3169657C004e5797fFE5be6653',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe",
+          "assets": [
+            "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+            "0x6e673502c5b55F3169657C004e5797fFE5be6653"
+          ]
+        }
+      ]
     },
     {
-      id: 'cKES-cUSD',
-      assets: [
+      "id": "cKES-cUSD",
+      "assets": [
         {
-          address: '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          symbol: 'cKES',
+          "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+          "symbol": "cKES"
         },
         {
-          address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-          symbol: 'cUSD',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-cEUR',
-      assets: [
+      "id": "USDC-cEUR",
+      "assets": [
         {
-          address: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          symbol: 'USDC',
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
         },
         {
-          address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-          symbol: 'cEUR',
-        },
+          "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+          "symbol": "cEUR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-cUSD',
-      assets: [
+      "id": "USDC-cUSD",
+      "assets": [
         {
-          address: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          symbol: 'USDC',
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
         },
         {
-          address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-          symbol: 'cUSD',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-cUSD',
-      assets: [
+      "id": "BridgedUSDC-cUSD",
+      "assets": [
         {
-          address: '0x87D61dA3d668797786D73BC674F053f87111570d',
-          symbol: 'BridgedUSDC',
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-          symbol: 'cUSD',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x87D61dA3d668797786D73BC674F053f87111570d',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDT-cUSD',
-      assets: [
+      "id": "USDT-cUSD",
+      "assets": [
         {
-          address: '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          symbol: 'USDT',
+          "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+          "symbol": "USDT"
         },
         {
-          address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-          symbol: 'cUSD',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-cUSD',
-      assets: [
+      "id": "PUSO-cUSD",
+      "assets": [
         {
-          address: '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          symbol: 'PUSO',
+          "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+          "symbol": "PUSO"
         },
         {
-          address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-          symbol: 'cUSD',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+          ]
+        }
+      ]
     },
     {
-      id: 'cCOP-cUSD',
-      assets: [
+      "id": "cCOP-cUSD",
+      "assets": [
         {
-          address: '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          symbol: 'cCOP',
+          "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+          "symbol": "cCOP"
         },
         {
-          address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-          symbol: 'cUSD',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          ]
+        }
+      ]
     },
     {
-      id: 'cGHS-cUSD',
-      assets: [
+      "id": "cGHS-cUSD",
+      "assets": [
         {
-          address: '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          symbol: 'cGHS',
+          "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+          "symbol": "cGHS"
         },
         {
-          address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-          symbol: 'cUSD',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cKES',
-      assets: [
+      "id": "cGBP-cUSD",
+      "assets": [
         {
-          address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          symbol: 'CELO',
+          "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+          "symbol": "cGBP"
         },
         {
-          address: '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          symbol: 'cKES',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-        {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-USDC',
-      assets: [
+      "id": "cUSD-cZAR",
+      "assets": [
         {
-          address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          symbol: 'CELO',
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
         },
         {
-          address: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          symbol: 'USDC',
-        },
+          "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+          "symbol": "cZAR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-        {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-CELO',
-      assets: [
+      "id": "cCAD-cUSD",
+      "assets": [
         {
-          address: '0x87D61dA3d668797786D73BC674F053f87111570d',
-          symbol: 'BridgedUSDC',
+          "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+          "symbol": "cCAD"
         },
         {
-          address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          symbol: 'CELO',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-        {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x87D61dA3d668797786D73BC674F053f87111570d',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-USDT',
-      assets: [
+      "id": "cAUD-cUSD",
+      "assets": [
         {
-          address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          symbol: 'CELO',
+          "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+          "symbol": "cAUD"
         },
         {
-          address: '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          symbol: 'USDT',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-        {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-PUSO',
-      assets: [
+      "id": "CELO-cKES",
+      "assets": [
         {
-          address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          symbol: 'CELO',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          symbol: 'PUSO',
-        },
+          "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cCOP',
-      assets: [
+      "id": "CELO-USDC",
+      "assets": [
         {
-          address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          symbol: 'CELO',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          symbol: 'cCOP',
-        },
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cGHS',
-      assets: [
+      "id": "BridgedUSDC-CELO",
+      "assets": [
         {
-          address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          symbol: 'CELO',
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          symbol: 'cGHS',
-        },
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedEUROC-CELO',
-      assets: [
+      "id": "CELO-USDT",
+      "assets": [
         {
-          address: '0x6e673502c5b55F3169657C004e5797fFE5be6653',
-          symbol: 'BridgedEUROC',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          symbol: 'CELO',
-        },
+          "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+          "symbol": "USDT"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0x6e673502c5b55F3169657C004e5797fFE5be6653',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          ]
+        }
+      ]
     },
     {
-      id: 'cEUR-cUSD',
-      assets: [
+      "id": "CELO-PUSO",
+      "assets": [
         {
-          address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-          symbol: 'cEUR',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-          symbol: 'cUSD',
-        },
+          "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+          "symbol": "PUSO"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+          ]
+        }
+      ]
     },
     {
-      id: 'cREAL-cUSD',
-      assets: [
+      "id": "CELO-cCOP",
+      "assets": [
         {
-          address: '0xE4D517785D091D3c54818832dB6094bcc2744545',
-          symbol: 'cREAL',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-          symbol: 'cUSD',
-        },
+          "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+          "symbol": "cCOP"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae',
-          assets: [
-            '0xE4D517785D091D3c54818832dB6094bcc2744545',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          ]
+        }
+      ]
     },
     {
-      id: 'cUSD-eXOF',
-      assets: [
+      "id": "CELO-cGHS",
+      "assets": [
         {
-          address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-          symbol: 'cUSD',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
-          symbol: 'eXOF',
-        },
+          "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+          "symbol": "cGHS"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
-          assets: [
-            '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          ]
+        }
+      ]
     },
     {
-      id: 'cEUR-cREAL',
-      assets: [
+      "id": "CELO-cGBP",
+      "assets": [
         {
-          address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-          symbol: 'cEUR',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0xE4D517785D091D3c54818832dB6094bcc2744545',
-          symbol: 'cREAL',
-        },
+          "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+          "symbol": "cGBP"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae',
-          assets: [
-            '0xE4D517785D091D3c54818832dB6094bcc2744545',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          ]
+        }
+      ]
     },
     {
-      id: 'cEUR-eXOF',
-      assets: [
+      "id": "CELO-cZAR",
+      "assets": [
         {
-          address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-          symbol: 'cEUR',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
-          symbol: 'eXOF',
-        },
+          "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+          "symbol": "cZAR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
-          assets: [
-            '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          ]
+        }
+      ]
     },
     {
-      id: 'cREAL-eXOF',
-      assets: [
+      "id": "CELO-cCAD",
+      "assets": [
         {
-          address: '0xE4D517785D091D3c54818832dB6094bcc2744545',
-          symbol: 'cREAL',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
-          symbol: 'eXOF',
-        },
+          "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+          "symbol": "cCAD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae',
-          assets: [
-            '0xE4D517785D091D3c54818832dB6094bcc2744545',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
-          assets: [
-            '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
-            '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-USDC',
-      assets: [
+      "id": "CELO-cAUD",
+      "assets": [
         {
-          address: '0x87D61dA3d668797786D73BC674F053f87111570d',
-          symbol: 'BridgedUSDC',
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
         },
         {
-          address: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          symbol: 'USDC',
-        },
+          "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+          "symbol": "cAUD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58',
-          assets: [
-            '0xE4D517785D091D3c54818832dB6094bcc2744545',
-            '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c',
-          assets: [
-            '0xE4D517785D091D3c54818832dB6094bcc2744545',
-            '0x87D61dA3d668797786D73BC674F053f87111570d',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedEUROC-USDC',
-      assets: [
+      "id": "BridgedEUROC-CELO",
+      "assets": [
         {
-          address: '0x6e673502c5b55F3169657C004e5797fFE5be6653',
-          symbol: 'BridgedEUROC',
+          "address": "0x6e673502c5b55F3169657C004e5797fFE5be6653",
+          "symbol": "BridgedEUROC"
         },
         {
-          address: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          symbol: 'USDC',
-        },
+          "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "symbol": "CELO"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0x6e673502c5b55F3169657C004e5797fFE5be6653',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0x6e673502c5b55F3169657C004e5797fFE5be6653"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-cKES',
-      assets: [
+      "id": "cEUR-cUSD",
+      "assets": [
         {
-          address: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          symbol: 'USDC',
+          "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+          "symbol": "cEUR"
         },
         {
-          address: '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          symbol: 'cKES',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-USDT',
-      assets: [
+      "id": "cREAL-cUSD",
+      "assets": [
         {
-          address: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          symbol: 'USDC',
+          "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+          "symbol": "cREAL"
         },
         {
-          address: '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          symbol: 'USDT',
-        },
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+          "assets": [
+            "0xE4D517785D091D3c54818832dB6094bcc2744545",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-USDC',
-      assets: [
+      "id": "cUSD-eXOF",
+      "assets": [
         {
-          address: '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          symbol: 'PUSO',
+          "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "symbol": "cUSD"
         },
         {
-          address: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          symbol: 'USDC',
-        },
+          "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "assets": [
+            "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-cCOP',
-      assets: [
+      "id": "cEUR-cREAL",
+      "assets": [
         {
-          address: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          symbol: 'USDC',
+          "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+          "symbol": "cEUR"
         },
         {
-          address: '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          symbol: 'cCOP',
-        },
+          "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+          "symbol": "cREAL"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+          "assets": [
+            "0xE4D517785D091D3c54818832dB6094bcc2744545",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDC-cGHS',
-      assets: [
+      "id": "cEUR-eXOF",
+      "assets": [
         {
-          address: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          symbol: 'USDC',
+          "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+          "symbol": "cEUR"
         },
         {
-          address: '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          symbol: 'cGHS',
-        },
+          "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "assets": [
+            "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedEUROC-BridgedUSDC',
-      assets: [
+      "id": "cREAL-eXOF",
+      "assets": [
         {
-          address: '0x6e673502c5b55F3169657C004e5797fFE5be6653',
-          symbol: 'BridgedEUROC',
+          "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+          "symbol": "cREAL"
         },
         {
-          address: '0x87D61dA3d668797786D73BC674F053f87111570d',
-          symbol: 'BridgedUSDC',
-        },
+          "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0x87D61dA3d668797786D73BC674F053f87111570d',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+          "assets": [
+            "0xE4D517785D091D3c54818832dB6094bcc2744545",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37',
-          assets: [
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-            '0x6e673502c5b55F3169657C004e5797fFE5be6653',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "assets": [
+            "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+            "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-cKES',
-      assets: [
+      "id": "BridgedUSDC-USDC",
+      "assets": [
         {
-          address: '0x87D61dA3d668797786D73BC674F053f87111570d',
-          symbol: 'BridgedUSDC',
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          symbol: 'cKES',
-        },
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x87D61dA3d668797786D73BC674F053f87111570d',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
+          "assets": [
+            "0xE4D517785D091D3c54818832dB6094bcc2744545",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
+          "assets": [
+            "0xE4D517785D091D3c54818832dB6094bcc2744545",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-USDT',
-      assets: [
+      "id": "BridgedEUROC-USDC",
+      "assets": [
         {
-          address: '0x87D61dA3d668797786D73BC674F053f87111570d',
-          symbol: 'BridgedUSDC',
+          "address": "0x6e673502c5b55F3169657C004e5797fFE5be6653",
+          "symbol": "BridgedEUROC"
         },
         {
-          address: '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          symbol: 'USDT',
-        },
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x87D61dA3d668797786D73BC674F053f87111570d',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0x6e673502c5b55F3169657C004e5797fFE5be6653"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-PUSO',
-      assets: [
+      "id": "USDC-cKES",
+      "assets": [
         {
-          address: '0x87D61dA3d668797786D73BC674F053f87111570d',
-          symbol: 'BridgedUSDC',
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
         },
         {
-          address: '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          symbol: 'PUSO',
-        },
+          "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x87D61dA3d668797786D73BC674F053f87111570d',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-cCOP',
-      assets: [
+      "id": "USDC-USDT",
+      "assets": [
         {
-          address: '0x87D61dA3d668797786D73BC674F053f87111570d',
-          symbol: 'BridgedUSDC',
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
         },
         {
-          address: '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          symbol: 'cCOP',
-        },
+          "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+          "symbol": "USDT"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x87D61dA3d668797786D73BC674F053f87111570d',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-cGHS',
-      assets: [
+      "id": "PUSO-USDC",
+      "assets": [
         {
-          address: '0x87D61dA3d668797786D73BC674F053f87111570d',
-          symbol: 'BridgedUSDC',
+          "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+          "symbol": "PUSO"
         },
         {
-          address: '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          symbol: 'cGHS',
-        },
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x87D61dA3d668797786D73BC674F053f87111570d',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDT-cKES',
-      assets: [
+      "id": "USDC-cCOP",
+      "assets": [
         {
-          address: '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          symbol: 'USDT',
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
         },
         {
-          address: '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          symbol: 'cKES',
-        },
+          "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+          "symbol": "cCOP"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-cKES',
-      assets: [
+      "id": "USDC-cGHS",
+      "assets": [
         {
-          address: '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          symbol: 'PUSO',
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
         },
         {
-          address: '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          symbol: 'cKES',
-        },
+          "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+          "symbol": "cGHS"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          ]
+        }
+      ]
     },
     {
-      id: 'cCOP-cKES',
-      assets: [
+      "id": "USDC-cGBP",
+      "assets": [
         {
-          address: '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          symbol: 'cCOP',
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
         },
         {
-          address: '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          symbol: 'cKES',
-        },
+          "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+          "symbol": "cGBP"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          ]
+        }
+      ]
     },
     {
-      id: 'cGHS-cKES',
-      assets: [
+      "id": "USDC-cZAR",
+      "assets": [
         {
-          address: '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          symbol: 'cGHS',
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
         },
         {
-          address: '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          symbol: 'cKES',
-        },
+          "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+          "symbol": "cZAR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-USDT',
-      assets: [
+      "id": "USDC-cCAD",
+      "assets": [
         {
-          address: '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          symbol: 'PUSO',
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
         },
         {
-          address: '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          symbol: 'USDT',
-        },
+          "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+          "symbol": "cCAD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDT-cCOP',
-      assets: [
+      "id": "USDC-cAUD",
+      "assets": [
         {
-          address: '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          symbol: 'USDT',
+          "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+          "symbol": "USDC"
         },
         {
-          address: '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          symbol: 'cCOP',
-        },
+          "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+          "symbol": "cAUD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDT-cGHS',
-      assets: [
+      "id": "BridgedEUROC-BridgedUSDC",
+      "assets": [
         {
-          address: '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          symbol: 'USDT',
+          "address": "0x6e673502c5b55F3169657C004e5797fFE5be6653",
+          "symbol": "BridgedEUROC"
         },
         {
-          address: '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          symbol: 'cGHS',
-        },
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
+          "assets": [
+            "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+            "0x6e673502c5b55F3169657C004e5797fFE5be6653"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-cCOP',
-      assets: [
+      "id": "BridgedUSDC-cKES",
+      "assets": [
         {
-          address: '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          symbol: 'PUSO',
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          symbol: 'cCOP',
-        },
+          "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+          ]
+        }
+      ]
     },
     {
-      id: 'PUSO-cGHS',
-      assets: [
+      "id": "BridgedUSDC-USDT",
+      "assets": [
         {
-          address: '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          symbol: 'PUSO',
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          symbol: 'cGHS',
-        },
+          "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+          "symbol": "USDT"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          ]
+        }
+      ]
     },
     {
-      id: 'cCOP-cGHS',
-      assets: [
+      "id": "BridgedUSDC-PUSO",
+      "assets": [
         {
-          address: '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          symbol: 'cCOP',
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          symbol: 'cGHS',
-        },
+          "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+          "symbol": "PUSO"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4',
-          ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
         },
         {
-          providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
-          id: '0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187',
-          assets: [
-            '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-            '0x295B66bE7714458Af45E6A6Ea142A5358A6cA375',
-          ],
-        },
-      ],
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+          ]
+        }
+      ]
     },
+    {
+      "id": "BridgedUSDC-cCOP",
+      "assets": [
+        {
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
+        },
+        {
+          "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+          "symbol": "cCOP"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "BridgedUSDC-cGHS",
+      "assets": [
+        {
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
+        },
+        {
+          "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+          "symbol": "cGHS"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "BridgedUSDC-cGBP",
+      "assets": [
+        {
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
+        },
+        {
+          "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+          "symbol": "cGBP"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "BridgedUSDC-cZAR",
+      "assets": [
+        {
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
+        },
+        {
+          "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+          "symbol": "cZAR"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "BridgedUSDC-cCAD",
+      "assets": [
+        {
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
+        },
+        {
+          "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+          "symbol": "cCAD"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "BridgedUSDC-cAUD",
+      "assets": [
+        {
+          "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+          "symbol": "BridgedUSDC"
+        },
+        {
+          "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+          "symbol": "cAUD"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x87D61dA3d668797786D73BC674F053f87111570d"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "USDT-cKES",
+      "assets": [
+        {
+          "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+          "symbol": "USDT"
+        },
+        {
+          "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+          "symbol": "cKES"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "PUSO-cKES",
+      "assets": [
+        {
+          "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+          "symbol": "PUSO"
+        },
+        {
+          "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+          "symbol": "cKES"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cCOP-cKES",
+      "assets": [
+        {
+          "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+          "symbol": "cCOP"
+        },
+        {
+          "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+          "symbol": "cKES"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cGHS-cKES",
+      "assets": [
+        {
+          "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+          "symbol": "cGHS"
+        },
+        {
+          "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+          "symbol": "cKES"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cGBP-cKES",
+      "assets": [
+        {
+          "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+          "symbol": "cGBP"
+        },
+        {
+          "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+          "symbol": "cKES"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cKES-cZAR",
+      "assets": [
+        {
+          "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+          "symbol": "cKES"
+        },
+        {
+          "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+          "symbol": "cZAR"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cCAD-cKES",
+      "assets": [
+        {
+          "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+          "symbol": "cCAD"
+        },
+        {
+          "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+          "symbol": "cKES"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cAUD-cKES",
+      "assets": [
+        {
+          "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+          "symbol": "cAUD"
+        },
+        {
+          "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+          "symbol": "cKES"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "PUSO-USDT",
+      "assets": [
+        {
+          "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+          "symbol": "PUSO"
+        },
+        {
+          "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+          "symbol": "USDT"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "USDT-cCOP",
+      "assets": [
+        {
+          "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+          "symbol": "USDT"
+        },
+        {
+          "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+          "symbol": "cCOP"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "USDT-cGHS",
+      "assets": [
+        {
+          "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+          "symbol": "USDT"
+        },
+        {
+          "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+          "symbol": "cGHS"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "USDT-cGBP",
+      "assets": [
+        {
+          "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+          "symbol": "USDT"
+        },
+        {
+          "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+          "symbol": "cGBP"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "USDT-cZAR",
+      "assets": [
+        {
+          "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+          "symbol": "USDT"
+        },
+        {
+          "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+          "symbol": "cZAR"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "USDT-cCAD",
+      "assets": [
+        {
+          "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+          "symbol": "USDT"
+        },
+        {
+          "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+          "symbol": "cCAD"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "USDT-cAUD",
+      "assets": [
+        {
+          "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+          "symbol": "USDT"
+        },
+        {
+          "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+          "symbol": "cAUD"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "PUSO-cCOP",
+      "assets": [
+        {
+          "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+          "symbol": "PUSO"
+        },
+        {
+          "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+          "symbol": "cCOP"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "PUSO-cGHS",
+      "assets": [
+        {
+          "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+          "symbol": "PUSO"
+        },
+        {
+          "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+          "symbol": "cGHS"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "PUSO-cGBP",
+      "assets": [
+        {
+          "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+          "symbol": "PUSO"
+        },
+        {
+          "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+          "symbol": "cGBP"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "PUSO-cZAR",
+      "assets": [
+        {
+          "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+          "symbol": "PUSO"
+        },
+        {
+          "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+          "symbol": "cZAR"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "PUSO-cCAD",
+      "assets": [
+        {
+          "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+          "symbol": "PUSO"
+        },
+        {
+          "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+          "symbol": "cCAD"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "PUSO-cAUD",
+      "assets": [
+        {
+          "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+          "symbol": "PUSO"
+        },
+        {
+          "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+          "symbol": "cAUD"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cCOP-cGHS",
+      "assets": [
+        {
+          "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+          "symbol": "cCOP"
+        },
+        {
+          "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+          "symbol": "cGHS"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cCOP-cGBP",
+      "assets": [
+        {
+          "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+          "symbol": "cCOP"
+        },
+        {
+          "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+          "symbol": "cGBP"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cCOP-cZAR",
+      "assets": [
+        {
+          "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+          "symbol": "cCOP"
+        },
+        {
+          "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+          "symbol": "cZAR"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cCAD-cCOP",
+      "assets": [
+        {
+          "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+          "symbol": "cCAD"
+        },
+        {
+          "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+          "symbol": "cCOP"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cAUD-cCOP",
+      "assets": [
+        {
+          "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+          "symbol": "cAUD"
+        },
+        {
+          "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+          "symbol": "cCOP"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cGBP-cGHS",
+      "assets": [
+        {
+          "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+          "symbol": "cGBP"
+        },
+        {
+          "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+          "symbol": "cGHS"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cGHS-cZAR",
+      "assets": [
+        {
+          "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+          "symbol": "cGHS"
+        },
+        {
+          "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+          "symbol": "cZAR"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cCAD-cGHS",
+      "assets": [
+        {
+          "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+          "symbol": "cCAD"
+        },
+        {
+          "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+          "symbol": "cGHS"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cAUD-cGHS",
+      "assets": [
+        {
+          "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+          "symbol": "cAUD"
+        },
+        {
+          "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+          "symbol": "cGHS"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cGBP-cZAR",
+      "assets": [
+        {
+          "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+          "symbol": "cGBP"
+        },
+        {
+          "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+          "symbol": "cZAR"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cCAD-cGBP",
+      "assets": [
+        {
+          "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+          "symbol": "cCAD"
+        },
+        {
+          "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+          "symbol": "cGBP"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cAUD-cGBP",
+      "assets": [
+        {
+          "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+          "symbol": "cAUD"
+        },
+        {
+          "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+          "symbol": "cGBP"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cCAD-cZAR",
+      "assets": [
+        {
+          "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+          "symbol": "cCAD"
+        },
+        {
+          "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+          "symbol": "cZAR"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cAUD-cZAR",
+      "assets": [
+        {
+          "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+          "symbol": "cAUD"
+        },
+        {
+          "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+          "symbol": "cZAR"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cAUD-cCAD",
+      "assets": [
+        {
+          "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+          "symbol": "cAUD"
+        },
+        {
+          "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+          "symbol": "cCAD"
+        }
+      ],
+      "path": [
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          ]
+        },
+        {
+          "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+          "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "assets": [
+            "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+            "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+          ]
+        }
+      ]
+    }
   ],
-  '62320': [
+  "62320": [
     {
-      id: 'CELO-cUSD',
-      assets: [
+      "id": "CELO-cUSD",
+      "assets": [
         {
-          address: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          symbol: 'CELO',
+          "address": "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8",
+          "symbol": "CELO"
         },
         {
-          address: '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-          symbol: 'cUSD',
-        },
+          "address": "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cEUR',
-      assets: [
+      "id": "CELO-cEUR",
+      "assets": [
         {
-          address: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          symbol: 'CELO',
+          "address": "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8",
+          "symbol": "CELO"
         },
         {
-          address: '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-          symbol: 'cEUR',
-        },
+          "address": "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+          "symbol": "cEUR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cREAL',
-      assets: [
+      "id": "CELO-cREAL",
+      "assets": [
         {
-          address: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          symbol: 'CELO',
+          "address": "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8",
+          "symbol": "CELO"
         },
         {
-          address: '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-          symbol: 'cREAL',
-        },
+          "address": "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+          "symbol": "cREAL"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae',
-          assets: [
-            '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+          "assets": [
+            "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
+        }
+      ]
     },
     {
-      id: 'cREAL-mockNativeUSDC',
-      assets: [
+      "id": "cREAL-mockNativeUSDC",
+      "assets": [
         {
-          address: '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-          symbol: 'cREAL',
+          "address": "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+          "symbol": "cREAL"
         },
         {
-          address: '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          symbol: 'mockNativeUSDC',
-        },
+          "address": "0xB407D37d76c417B6343310D42611FCA106B2abB8",
+          "symbol": "mockNativeUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xbfd96ed0ed5098d2b2bff8b9d8423dc47001fccf2391ee6e532618ef79c12075',
-          assets: [
-            '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-            '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xbfd96ed0ed5098d2b2bff8b9d8423dc47001fccf2391ee6e532618ef79c12075",
+          "assets": [
+            "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+            "0xB407D37d76c417B6343310D42611FCA106B2abB8"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-cEUR',
-      assets: [
+      "id": "BridgedUSDC-cEUR",
+      "assets": [
         {
-          address: '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          symbol: 'BridgedUSDC',
+          "address": "0xD4079B322c392D6b196f90AA4c439fC2C16d6770",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-          symbol: 'cEUR',
-        },
+          "address": "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+          "symbol": "cEUR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0xD4079B322c392D6b196f90AA4c439fC2C16d6770"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-cREAL',
-      assets: [
+      "id": "BridgedUSDC-cREAL",
+      "assets": [
         {
-          address: '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          symbol: 'BridgedUSDC',
+          "address": "0xD4079B322c392D6b196f90AA4c439fC2C16d6770",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-          symbol: 'cREAL',
-        },
+          "address": "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+          "symbol": "cREAL"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c',
-          assets: [
-            '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-            '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
+          "assets": [
+            "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+            "0xD4079B322c392D6b196f90AA4c439fC2C16d6770"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedEUROC-cEUR',
-      assets: [
+      "id": "BridgedEUROC-cEUR",
+      "assets": [
         {
-          address: '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
-          symbol: 'BridgedEUROC',
+          "address": "0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B",
+          "symbol": "BridgedEUROC"
         },
         {
-          address: '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-          symbol: 'cEUR',
-        },
+          "address": "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+          "symbol": "cEUR"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-eXOF',
-      assets: [
+      "id": "CELO-eXOF",
+      "assets": [
         {
-          address: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          symbol: 'CELO',
+          "address": "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8",
+          "symbol": "CELO"
         },
         {
-          address: '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
-          symbol: 'eXOF',
-        },
+          "address": "0x64c1D812673E93Bc036AdC3D547d9950696DA5Af",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
-          assets: [
-            '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "assets": [
+            "0x64c1D812673E93Bc036AdC3D547d9950696DA5Af",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedEUROC-eXOF',
-      assets: [
+      "id": "BridgedEUROC-eXOF",
+      "assets": [
         {
-          address: '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
-          symbol: 'BridgedEUROC',
+          "address": "0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B",
+          "symbol": "BridgedEUROC"
         },
         {
-          address: '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
-          symbol: 'eXOF',
-        },
+          "address": "0x64c1D812673E93Bc036AdC3D547d9950696DA5Af",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe',
-          assets: [
-            '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
-            '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe",
+          "assets": [
+            "0x64c1D812673E93Bc036AdC3D547d9950696DA5Af",
+            "0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B"
+          ]
+        }
+      ]
     },
     {
-      id: 'cKES-cUSD',
-      assets: [
+      "id": "cKES-cUSD",
+      "assets": [
         {
-          address: '0x8813Ae180017057d0Cf98C930cED1E7101B97370',
-          symbol: 'cKES',
+          "address": "0x8813Ae180017057d0Cf98C930cED1E7101B97370",
+          "symbol": "cKES"
         },
         {
-          address: '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-          symbol: 'cUSD',
-        },
+          "address": "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0x8813Ae180017057d0Cf98C930cED1E7101B97370',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0x8813Ae180017057d0Cf98C930cED1E7101B97370"
+          ]
+        }
+      ]
     },
     {
-      id: 'cEUR-mockNativeUSDC',
-      assets: [
+      "id": "cEUR-mockNativeUSDC",
+      "assets": [
         {
-          address: '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-          symbol: 'cEUR',
+          "address": "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+          "symbol": "cEUR"
         },
         {
-          address: '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          symbol: 'mockNativeUSDC',
-        },
+          "address": "0xB407D37d76c417B6343310D42611FCA106B2abB8",
+          "symbol": "mockNativeUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x3839dd748e34fa87f5cd928e10d3e0ecafd9230ac9932c6cb2b0d5a358b72618',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x3839dd748e34fa87f5cd928e10d3e0ecafd9230ac9932c6cb2b0d5a358b72618",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0xB407D37d76c417B6343310D42611FCA106B2abB8"
+          ]
+        }
+      ]
     },
     {
-      id: 'cUSD-mockNativeUSDC',
-      assets: [
+      "id": "cUSD-mockNativeUSDC",
+      "assets": [
         {
-          address: '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-          symbol: 'cUSD',
+          "address": "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+          "symbol": "cUSD"
         },
         {
-          address: '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          symbol: 'mockNativeUSDC',
-        },
+          "address": "0xB407D37d76c417B6343310D42611FCA106B2abB8",
+          "symbol": "mockNativeUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xd8573fd7c4151f38cde9b2349a26a6bb03be4b3791105bc625731ad2d71c54ba',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xd8573fd7c4151f38cde9b2349a26a6bb03be4b3791105bc625731ad2d71c54ba",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xB407D37d76c417B6343310D42611FCA106B2abB8"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-cUSD',
-      assets: [
+      "id": "BridgedUSDC-cUSD",
+      "assets": [
         {
-          address: '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          symbol: 'BridgedUSDC',
+          "address": "0xD4079B322c392D6b196f90AA4c439fC2C16d6770",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-          symbol: 'cUSD',
-        },
+          "address": "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xD4079B322c392D6b196f90AA4c439fC2C16d6770"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDT-cUSD',
-      assets: [
+      "id": "USDT-cUSD",
+      "assets": [
         {
-          address: '0x27c586469038A1749B27BF5914DAff7A14227AfB',
-          symbol: 'USDT',
+          "address": "0x27c586469038A1749B27BF5914DAff7A14227AfB",
+          "symbol": "USDT"
         },
         {
-          address: '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-          symbol: 'cUSD',
-        },
+          "address": "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0x27c586469038A1749B27BF5914DAff7A14227AfB',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0x27c586469038A1749B27BF5914DAff7A14227AfB"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-cKES',
-      assets: [
+      "id": "CELO-cKES",
+      "assets": [
         {
-          address: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          symbol: 'CELO',
+          "address": "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8",
+          "symbol": "CELO"
         },
         {
-          address: '0x8813Ae180017057d0Cf98C930cED1E7101B97370',
-          symbol: 'cKES',
-        },
+          "address": "0x8813Ae180017057d0Cf98C930cED1E7101B97370",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0x8813Ae180017057d0Cf98C930cED1E7101B97370',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0x8813Ae180017057d0Cf98C930cED1E7101B97370"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-mockNativeUSDC',
-      assets: [
+      "id": "CELO-mockNativeUSDC",
+      "assets": [
         {
-          address: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          symbol: 'CELO',
+          "address": "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8",
+          "symbol": "CELO"
         },
         {
-          address: '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          symbol: 'mockNativeUSDC',
-        },
+          "address": "0xB407D37d76c417B6343310D42611FCA106B2abB8",
+          "symbol": "mockNativeUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xd8573fd7c4151f38cde9b2349a26a6bb03be4b3791105bc625731ad2d71c54ba',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xd8573fd7c4151f38cde9b2349a26a6bb03be4b3791105bc625731ad2d71c54ba",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xB407D37d76c417B6343310D42611FCA106B2abB8"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-CELO',
-      assets: [
+      "id": "BridgedUSDC-CELO",
+      "assets": [
         {
-          address: '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          symbol: 'BridgedUSDC',
+          "address": "0xD4079B322c392D6b196f90AA4c439fC2C16d6770",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          symbol: 'CELO',
-        },
+          "address": "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8",
+          "symbol": "CELO"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xD4079B322c392D6b196f90AA4c439fC2C16d6770"
+          ]
+        }
+      ]
     },
     {
-      id: 'CELO-USDT',
-      assets: [
+      "id": "CELO-USDT",
+      "assets": [
         {
-          address: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          symbol: 'CELO',
+          "address": "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8",
+          "symbol": "CELO"
         },
         {
-          address: '0x27c586469038A1749B27BF5914DAff7A14227AfB',
-          symbol: 'USDT',
-        },
+          "address": "0x27c586469038A1749B27BF5914DAff7A14227AfB",
+          "symbol": "USDT"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0x27c586469038A1749B27BF5914DAff7A14227AfB',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0x27c586469038A1749B27BF5914DAff7A14227AfB"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedEUROC-CELO',
-      assets: [
+      "id": "BridgedEUROC-CELO",
+      "assets": [
         {
-          address: '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
-          symbol: 'BridgedEUROC',
+          "address": "0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B",
+          "symbol": "BridgedEUROC"
         },
         {
-          address: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          symbol: 'CELO',
-        },
+          "address": "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8",
+          "symbol": "CELO"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B"
+          ]
+        }
+      ]
     },
     {
-      id: 'cEUR-cUSD',
-      assets: [
+      "id": "cEUR-cUSD",
+      "assets": [
         {
-          address: '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-          symbol: 'cEUR',
+          "address": "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+          "symbol": "cEUR"
         },
         {
-          address: '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-          symbol: 'cUSD',
-        },
+          "address": "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
+        }
+      ]
     },
     {
-      id: 'cREAL-cUSD',
-      assets: [
+      "id": "cREAL-cUSD",
+      "assets": [
         {
-          address: '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-          symbol: 'cREAL',
+          "address": "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+          "symbol": "cREAL"
         },
         {
-          address: '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-          symbol: 'cUSD',
-        },
+          "address": "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+          "symbol": "cUSD"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae',
-          assets: [
-            '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+          "assets": [
+            "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
+        }
+      ]
     },
     {
-      id: 'cUSD-eXOF',
-      assets: [
+      "id": "cUSD-eXOF",
+      "assets": [
         {
-          address: '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-          symbol: 'cUSD',
+          "address": "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+          "symbol": "cUSD"
         },
         {
-          address: '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
-          symbol: 'eXOF',
-        },
+          "address": "0x64c1D812673E93Bc036AdC3D547d9950696DA5Af",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
-          assets: [
-            '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "assets": [
+            "0x64c1D812673E93Bc036AdC3D547d9950696DA5Af",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
+        }
+      ]
     },
     {
-      id: 'cEUR-cREAL',
-      assets: [
+      "id": "cEUR-cREAL",
+      "assets": [
         {
-          address: '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-          symbol: 'cEUR',
+          "address": "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+          "symbol": "cEUR"
         },
         {
-          address: '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-          symbol: 'cREAL',
-        },
+          "address": "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+          "symbol": "cREAL"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae',
-          assets: [
-            '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+          "assets": [
+            "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
+        }
+      ]
     },
     {
-      id: 'cEUR-eXOF',
-      assets: [
+      "id": "cEUR-eXOF",
+      "assets": [
         {
-          address: '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-          symbol: 'cEUR',
+          "address": "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+          "symbol": "cEUR"
         },
         {
-          address: '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
-          symbol: 'eXOF',
-        },
+          "address": "0x64c1D812673E93Bc036AdC3D547d9950696DA5Af",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
-          assets: [
-            '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "assets": [
+            "0x64c1D812673E93Bc036AdC3D547d9950696DA5Af",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
+        }
+      ]
     },
     {
-      id: 'cREAL-eXOF',
-      assets: [
+      "id": "cREAL-eXOF",
+      "assets": [
         {
-          address: '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-          symbol: 'cREAL',
+          "address": "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+          "symbol": "cREAL"
         },
         {
-          address: '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
-          symbol: 'eXOF',
-        },
+          "address": "0x64c1D812673E93Bc036AdC3D547d9950696DA5Af",
+          "symbol": "eXOF"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae',
-          assets: [
-            '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+          "assets": [
+            "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
-          assets: [
-            '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
-            '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "assets": [
+            "0x64c1D812673E93Bc036AdC3D547d9950696DA5Af",
+            "0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-mockNativeUSDC',
-      assets: [
+      "id": "BridgedUSDC-mockNativeUSDC",
+      "assets": [
         {
-          address: '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          symbol: 'BridgedUSDC',
+          "address": "0xD4079B322c392D6b196f90AA4c439fC2C16d6770",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          symbol: 'mockNativeUSDC',
-        },
+          "address": "0xB407D37d76c417B6343310D42611FCA106B2abB8",
+          "symbol": "mockNativeUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xbfd96ed0ed5098d2b2bff8b9d8423dc47001fccf2391ee6e532618ef79c12075',
-          assets: [
-            '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-            '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xbfd96ed0ed5098d2b2bff8b9d8423dc47001fccf2391ee6e532618ef79c12075",
+          "assets": [
+            "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+            "0xB407D37d76c417B6343310D42611FCA106B2abB8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c',
-          assets: [
-            '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
-            '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
+          "assets": [
+            "0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1",
+            "0xD4079B322c392D6b196f90AA4c439fC2C16d6770"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedEUROC-mockNativeUSDC',
-      assets: [
+      "id": "BridgedEUROC-mockNativeUSDC",
+      "assets": [
         {
-          address: '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
-          symbol: 'BridgedEUROC',
+          "address": "0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B",
+          "symbol": "BridgedEUROC"
         },
         {
-          address: '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          symbol: 'mockNativeUSDC',
-        },
+          "address": "0xB407D37d76c417B6343310D42611FCA106B2abB8",
+          "symbol": "mockNativeUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x3839dd748e34fa87f5cd928e10d3e0ecafd9230ac9932c6cb2b0d5a358b72618',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x3839dd748e34fa87f5cd928e10d3e0ecafd9230ac9932c6cb2b0d5a358b72618",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0xB407D37d76c417B6343310D42611FCA106B2abB8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B"
+          ]
+        }
+      ]
     },
     {
-      id: 'cKES-mockNativeUSDC',
-      assets: [
+      "id": "cKES-mockNativeUSDC",
+      "assets": [
         {
-          address: '0x8813Ae180017057d0Cf98C930cED1E7101B97370',
-          symbol: 'cKES',
+          "address": "0x8813Ae180017057d0Cf98C930cED1E7101B97370",
+          "symbol": "cKES"
         },
         {
-          address: '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          symbol: 'mockNativeUSDC',
-        },
+          "address": "0xB407D37d76c417B6343310D42611FCA106B2abB8",
+          "symbol": "mockNativeUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xd8573fd7c4151f38cde9b2349a26a6bb03be4b3791105bc625731ad2d71c54ba',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xd8573fd7c4151f38cde9b2349a26a6bb03be4b3791105bc625731ad2d71c54ba",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xB407D37d76c417B6343310D42611FCA106B2abB8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0x8813Ae180017057d0Cf98C930cED1E7101B97370',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0x8813Ae180017057d0Cf98C930cED1E7101B97370"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDT-mockNativeUSDC',
-      assets: [
+      "id": "USDT-mockNativeUSDC",
+      "assets": [
         {
-          address: '0x27c586469038A1749B27BF5914DAff7A14227AfB',
-          symbol: 'USDT',
+          "address": "0x27c586469038A1749B27BF5914DAff7A14227AfB",
+          "symbol": "USDT"
         },
         {
-          address: '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          symbol: 'mockNativeUSDC',
-        },
+          "address": "0xB407D37d76c417B6343310D42611FCA106B2abB8",
+          "symbol": "mockNativeUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xd8573fd7c4151f38cde9b2349a26a6bb03be4b3791105bc625731ad2d71c54ba',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xB407D37d76c417B6343310D42611FCA106B2abB8',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xd8573fd7c4151f38cde9b2349a26a6bb03be4b3791105bc625731ad2d71c54ba",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xB407D37d76c417B6343310D42611FCA106B2abB8"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0x27c586469038A1749B27BF5914DAff7A14227AfB',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0x27c586469038A1749B27BF5914DAff7A14227AfB"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedEUROC-BridgedUSDC',
-      assets: [
+      "id": "BridgedEUROC-BridgedUSDC",
+      "assets": [
         {
-          address: '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
-          symbol: 'BridgedEUROC',
+          "address": "0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B",
+          "symbol": "BridgedEUROC"
         },
         {
-          address: '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          symbol: 'BridgedUSDC',
-        },
+          "address": "0xD4079B322c392D6b196f90AA4c439fC2C16d6770",
+          "symbol": "BridgedUSDC"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0xD4079B322c392D6b196f90AA4c439fC2C16d6770"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37',
-          assets: [
-            '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
-            '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
+          "assets": [
+            "0xf9ecE301247aD2CE21894941830A2470f4E774ca",
+            "0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-cKES',
-      assets: [
+      "id": "BridgedUSDC-cKES",
+      "assets": [
         {
-          address: '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          symbol: 'BridgedUSDC',
+          "address": "0xD4079B322c392D6b196f90AA4c439fC2C16d6770",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0x8813Ae180017057d0Cf98C930cED1E7101B97370',
-          symbol: 'cKES',
-        },
+          "address": "0x8813Ae180017057d0Cf98C930cED1E7101B97370",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xD4079B322c392D6b196f90AA4c439fC2C16d6770"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0x8813Ae180017057d0Cf98C930cED1E7101B97370',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0x8813Ae180017057d0Cf98C930cED1E7101B97370"
+          ]
+        }
+      ]
     },
     {
-      id: 'BridgedUSDC-USDT',
-      assets: [
+      "id": "BridgedUSDC-USDT",
+      "assets": [
         {
-          address: '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          symbol: 'BridgedUSDC',
+          "address": "0xD4079B322c392D6b196f90AA4c439fC2C16d6770",
+          "symbol": "BridgedUSDC"
         },
         {
-          address: '0x27c586469038A1749B27BF5914DAff7A14227AfB',
-          symbol: 'USDT',
-        },
+          "address": "0x27c586469038A1749B27BF5914DAff7A14227AfB",
+          "symbol": "USDT"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0xD4079B322c392D6b196f90AA4c439fC2C16d6770"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0x27c586469038A1749B27BF5914DAff7A14227AfB',
-          ],
-        },
-      ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0x27c586469038A1749B27BF5914DAff7A14227AfB"
+          ]
+        }
+      ]
     },
     {
-      id: 'USDT-cKES',
-      assets: [
+      "id": "USDT-cKES",
+      "assets": [
         {
-          address: '0x27c586469038A1749B27BF5914DAff7A14227AfB',
-          symbol: 'USDT',
+          "address": "0x27c586469038A1749B27BF5914DAff7A14227AfB",
+          "symbol": "USDT"
         },
         {
-          address: '0x8813Ae180017057d0Cf98C930cED1E7101B97370',
-          symbol: 'cKES',
-        },
+          "address": "0x8813Ae180017057d0Cf98C930cED1E7101B97370",
+          "symbol": "cKES"
+        }
       ],
-      path: [
+      "path": [
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0x8813Ae180017057d0Cf98C930cED1E7101B97370',
-          ],
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0x8813Ae180017057d0Cf98C930cED1E7101B97370"
+          ]
         },
         {
-          providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
-          id: '0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763',
-          assets: [
-            '0x62492A644A588FD904270BeD06ad52B9abfEA1aE',
-            '0x27c586469038A1749B27BF5914DAff7A14227AfB',
-          ],
-        },
-      ],
-    },
-  ],
-}
+          "providerAddr": "0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411",
+          "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "assets": [
+            "0x62492A644A588FD904270BeD06ad52B9abfEA1aE",
+            "0x27c586469038A1749B27BF5914DAff7A14227AfB"
+          ]
+        }
+      ]
+    }
+  ]
+};
 
-export function getCachedTradablePairs(
-  chainId: number
-): TradablePair[] | undefined {
+export function getCachedTradablePairs(chainId: number): TradablePair[] | undefined {
   return TRADABLE_PAIRS[chainId]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1537,405 +1537,405 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/abi@npm:5.7.0, @ethersproject/abi@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/abi@npm:5.7.0"
+"@ethersproject/abi@npm:5.8.0, @ethersproject/abi@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/abi@npm:5.8.0"
   dependencies:
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/hash": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-  checksum: bc6962bb6cb854e4d2a4d65b2c49c716477675b131b1363312234bdbb7e19badb7d9ce66f4ca2a70ae2ea84f7123dbc4e300a1bfe5d58864a7eafabc1466627e
+    "@ethersproject/address": ^5.8.0
+    "@ethersproject/bignumber": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/constants": ^5.8.0
+    "@ethersproject/hash": ^5.8.0
+    "@ethersproject/keccak256": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+    "@ethersproject/strings": ^5.8.0
+  checksum: cdab990d520fdbfd63d4a8829e78a2d2d2cc110dc3461895bd9014a49d3a9028c2005a11e2569c3fd620cb7780dcb5c71402630a8082a9ca5f85d4f8700d4549
   languageName: node
   linkType: hard
 
-"@ethersproject/abstract-provider@npm:5.7.0, @ethersproject/abstract-provider@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/abstract-provider@npm:5.7.0"
+"@ethersproject/abstract-provider@npm:5.8.0, @ethersproject/abstract-provider@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/abstract-provider@npm:5.8.0"
   dependencies:
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/networks": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-    "@ethersproject/web": ^5.7.0
-  checksum: 74cf4696245cf03bb7cc5b6cbf7b4b89dd9a79a1c4688126d214153a938126d4972d42c93182198653ce1de35f2a2cad68be40337d4774b3698a39b28f0228a8
+    "@ethersproject/bignumber": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/networks": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+    "@ethersproject/transactions": ^5.8.0
+    "@ethersproject/web": ^5.8.0
+  checksum: 4fd00d770552af53be297c676f31d938f5dc44d73c24970036a11237a53f114cc1c551fd95937b9eca790f77087da1ed3ec54f97071df088d5861f575fd4f9be
   languageName: node
   linkType: hard
 
-"@ethersproject/abstract-signer@npm:5.7.0, @ethersproject/abstract-signer@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/abstract-signer@npm:5.7.0"
+"@ethersproject/abstract-signer@npm:5.8.0, @ethersproject/abstract-signer@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/abstract-signer@npm:5.8.0"
   dependencies:
-    "@ethersproject/abstract-provider": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-  checksum: a823dac9cfb761e009851050ebebd5b229d1b1cc4a75b125c2da130ff37e8218208f7f9d1386f77407705b889b23d4a230ad67185f8872f083143e0073cbfbe3
+    "@ethersproject/abstract-provider": ^5.8.0
+    "@ethersproject/bignumber": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+  checksum: 3f7a98caf7c01e58da45d879c08449d1443bced36ac81938789c90d8f9ff86a1993655bae9805fc7b31a723b7bd7b4f1f768a9ec65dff032d0ebdc93133c14f3
   languageName: node
   linkType: hard
 
-"@ethersproject/address@npm:5.7.0, @ethersproject/address@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/address@npm:5.7.0"
+"@ethersproject/address@npm:5.8.0, @ethersproject/address@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/address@npm:5.8.0"
   dependencies:
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/rlp": ^5.7.0
-  checksum: 64ea5ebea9cc0e845c413e6cb1e54e157dd9fc0dffb98e239d3a3efc8177f2ff798cd4e3206cf3660ee8faeb7bef1a47dc0ebef0d7b132c32e61e550c7d4c843
+    "@ethersproject/bignumber": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/keccak256": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/rlp": ^5.8.0
+  checksum: fa48e16403b656207f996ee7796f0978a146682f10f345b75aa382caa4a70fbfdc6ff585e9955e4779f4f15a31628929b665d288b895cea5df206c070266aea1
   languageName: node
   linkType: hard
 
-"@ethersproject/base64@npm:5.7.0, @ethersproject/base64@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/base64@npm:5.7.0"
+"@ethersproject/base64@npm:5.8.0, @ethersproject/base64@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/base64@npm:5.8.0"
   dependencies:
-    "@ethersproject/bytes": ^5.7.0
-  checksum: 7dd5d734d623582f08f665434f53685041a3d3b334a0e96c0c8afa8bbcaab934d50e5b6b980e826a8fde8d353e0b18f11e61faf17468177274b8e7c69cd9742b
+    "@ethersproject/bytes": ^5.8.0
+  checksum: f0c2136c99b2fd2f93b7e110958eacc5990e88274b1f38eb73d8eaa31bdead75fc0c4608dac23cb5718ae455b965de9dc5023446b96de62ef1fa945cbf212096
   languageName: node
   linkType: hard
 
-"@ethersproject/basex@npm:5.7.0, @ethersproject/basex@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/basex@npm:5.7.0"
+"@ethersproject/basex@npm:5.8.0, @ethersproject/basex@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/basex@npm:5.8.0"
   dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-  checksum: 326087b7e1f3787b5fe6cd1cf2b4b5abfafbc355a45e88e22e5e9d6c845b613ffc5301d629b28d5c4d5e2bfe9ec424e6782c804956dff79be05f0098cb5817de
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+  checksum: 7b502b91011d3aac9bf38d77aad113632440a1eab6a966ffbe2c23f9e3758a4dcb2a4189ab2948d6996250d0cb716d7445e7e2103d03b94097a77c0e128f9ab7
   languageName: node
   linkType: hard
 
-"@ethersproject/bignumber@npm:5.7.0, @ethersproject/bignumber@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/bignumber@npm:5.7.0"
+"@ethersproject/bignumber@npm:5.8.0, @ethersproject/bignumber@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/bignumber@npm:5.8.0"
   dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
     bn.js: ^5.2.1
-  checksum: 8c9a134b76f3feb4ec26a5a27379efb4e156b8fb2de0678a67788a91c7f4e30abe9d948638458e4b20f2e42380da0adacc7c9389d05fce070692edc6ae9b4904
+  checksum: c87017f466b32d482e4b39370016cfc3edafc2feb89377011c54cd2e7dd011072ef4f275df59cd9fe080a187066082c1808b2682d97547c4fb9e6912331200c3
   languageName: node
   linkType: hard
 
-"@ethersproject/bytes@npm:5.7.0, @ethersproject/bytes@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/bytes@npm:5.7.0"
+"@ethersproject/bytes@npm:5.8.0, @ethersproject/bytes@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/bytes@npm:5.8.0"
   dependencies:
-    "@ethersproject/logger": ^5.7.0
-  checksum: 66ad365ceaab5da1b23b72225c71dce472cf37737af5118181fa8ab7447d696bea15ca22e3a0e8836fdd8cfac161afe321a7c67d0dde96f9f645ddd759676621
+    "@ethersproject/logger": ^5.8.0
+  checksum: 507e8ef1f1559590b4e78e3392a2b16090e96fb1091e0b08d3a8491df65976b313c29cdb412594454f68f9f04d5f77ea5a400b489d80a3e46a608156ef31b251
   languageName: node
   linkType: hard
 
-"@ethersproject/constants@npm:5.7.0, @ethersproject/constants@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/constants@npm:5.7.0"
+"@ethersproject/constants@npm:5.8.0, @ethersproject/constants@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/constants@npm:5.8.0"
   dependencies:
-    "@ethersproject/bignumber": ^5.7.0
-  checksum: 6d4b1355747cce837b3e76ec3bde70e4732736f23b04f196f706ebfa5d4d9c2be50904a390d4d40ce77803b98d03d16a9b6898418e04ba63491933ce08c4ba8a
+    "@ethersproject/bignumber": ^5.8.0
+  checksum: 74830c44f4315a1058b905c73be7a9bb92850e45213cb28a957447b8a100f22a514f4500b0ea5ac7a995427cecef9918af39ae4e0e0ecf77aa4835b1ea5c3432
   languageName: node
   linkType: hard
 
-"@ethersproject/contracts@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/contracts@npm:5.7.0"
+"@ethersproject/contracts@npm:5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/contracts@npm:5.8.0"
   dependencies:
-    "@ethersproject/abi": ^5.7.0
-    "@ethersproject/abstract-provider": ^5.7.0
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-  checksum: 6ccf1121cba01b31e02f8c507cb971ab6bfed85706484a9ec09878ef1594a62215f43c4fdef8f4a4875b99c4a800bc95e3be69b1803f8ce479e07634b5a740c0
+    "@ethersproject/abi": ^5.8.0
+    "@ethersproject/abstract-provider": ^5.8.0
+    "@ethersproject/abstract-signer": ^5.8.0
+    "@ethersproject/address": ^5.8.0
+    "@ethersproject/bignumber": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/constants": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+    "@ethersproject/transactions": ^5.8.0
+  checksum: cb181012bd55cc19c08f136e56e28e922f1ca66af66747a1b3f58a2aea5b3332bc7ecfe2d23fa14245e7fd45a4fdc4f3427a345c2e9873a9792838cdfe4c62d5
   languageName: node
   linkType: hard
 
-"@ethersproject/hash@npm:5.7.0, @ethersproject/hash@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/hash@npm:5.7.0"
+"@ethersproject/hash@npm:5.8.0, @ethersproject/hash@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/hash@npm:5.8.0"
   dependencies:
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/base64": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-  checksum: 6e9fa8d14eb08171cd32f17f98cc108ec2aeca74a427655f0d689c550fee0b22a83b3b400fad7fb3f41cf14d4111f87f170aa7905bcbcd1173a55f21b06262ef
+    "@ethersproject/abstract-signer": ^5.8.0
+    "@ethersproject/address": ^5.8.0
+    "@ethersproject/base64": ^5.8.0
+    "@ethersproject/bignumber": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/keccak256": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+    "@ethersproject/strings": ^5.8.0
+  checksum: e1feb47a98c631548b0f98ef0b1eb1b964bc643d5dea12a0eeb533165004cfcfe6f1d2bb32f31941f0b91e6a82212ad5c8577d6d465fba62c38fc0c410941feb
   languageName: node
   linkType: hard
 
-"@ethersproject/hdnode@npm:5.7.0, @ethersproject/hdnode@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/hdnode@npm:5.7.0"
+"@ethersproject/hdnode@npm:5.8.0, @ethersproject/hdnode@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/hdnode@npm:5.8.0"
   dependencies:
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/basex": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/pbkdf2": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/sha2": ^5.7.0
-    "@ethersproject/signing-key": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-    "@ethersproject/wordlists": ^5.7.0
-  checksum: bfe5ca2d89a42de73655f853170ef4766b933c5f481cddad709b3aca18823275b096e572f92d1602a052f80b426edde44ad6b9d028799775a7dad4a5bbed2133
+    "@ethersproject/abstract-signer": ^5.8.0
+    "@ethersproject/basex": ^5.8.0
+    "@ethersproject/bignumber": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/pbkdf2": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+    "@ethersproject/sha2": ^5.8.0
+    "@ethersproject/signing-key": ^5.8.0
+    "@ethersproject/strings": ^5.8.0
+    "@ethersproject/transactions": ^5.8.0
+    "@ethersproject/wordlists": ^5.8.0
+  checksum: 72cc6bd218dbe3565b915f3fd8654562003b1b160a5ace8c8959e319333712a0951887641f6888ef91017a39bb804204fc09fb7e5064e3acf76ad701c2ff1266
   languageName: node
   linkType: hard
 
-"@ethersproject/json-wallets@npm:5.7.0, @ethersproject/json-wallets@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/json-wallets@npm:5.7.0"
+"@ethersproject/json-wallets@npm:5.8.0, @ethersproject/json-wallets@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/json-wallets@npm:5.8.0"
   dependencies:
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/hdnode": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/pbkdf2": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/random": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
+    "@ethersproject/abstract-signer": ^5.8.0
+    "@ethersproject/address": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/hdnode": ^5.8.0
+    "@ethersproject/keccak256": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/pbkdf2": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+    "@ethersproject/random": ^5.8.0
+    "@ethersproject/strings": ^5.8.0
+    "@ethersproject/transactions": ^5.8.0
     aes-js: 3.0.0
     scrypt-js: 3.0.1
-  checksum: f583458d22db62efaaf94d38dd243482776a45bf90f9f3882fbad5aa0b8fd288b41eb7c1ff8ec0b99c9b751088e43d6173530db64dd33c59f9d8daa8d7ad5aa2
+  checksum: 8e0f8529f683d0a3fab1c76173bfccf7fc03a27e291344c86797815872722770be787e91f8fa83c37b0abfc47d5f2a2d0eca0ab862effb5539ad545e317f8d83
   languageName: node
   linkType: hard
 
-"@ethersproject/keccak256@npm:5.7.0, @ethersproject/keccak256@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/keccak256@npm:5.7.0"
+"@ethersproject/keccak256@npm:5.8.0, @ethersproject/keccak256@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/keccak256@npm:5.8.0"
   dependencies:
-    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/bytes": ^5.8.0
     js-sha3: 0.8.0
-  checksum: ff70950d82203aab29ccda2553422cbac2e7a0c15c986bd20a69b13606ed8bb6e4fdd7b67b8d3b27d4f841e8222cbaccd33ed34be29f866fec7308f96ed244c6
+  checksum: af3621d2b18af6c8f5181dacad91e1f6da4e8a6065668b20e4c24684bdb130b31e45e0d4dbaed86d4f1314d01358aa119f05be541b696e455424c47849d81913
   languageName: node
   linkType: hard
 
-"@ethersproject/logger@npm:5.7.0, @ethersproject/logger@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/logger@npm:5.7.0"
-  checksum: 075ab2f605f1fd0813f2e39c3308f77b44a67732b36e712d9bc085f22a84aac4da4f71b39bee50fe78da3e1c812673fadc41180c9970fe5e486e91ea17befe0d
+"@ethersproject/logger@npm:5.8.0, @ethersproject/logger@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/logger@npm:5.8.0"
+  checksum: 6249885a7fd4a5806e4c8700b76ffcc8f1ff00d71f31aa717716a89fa6b391de19fbb0cb5ae2560b9f57ec0c2e8e0a11ebc2099124c73d3b42bc58e3eedc41d1
   languageName: node
   linkType: hard
 
-"@ethersproject/networks@npm:5.7.1, @ethersproject/networks@npm:^5.7.0":
-  version: 5.7.1
-  resolution: "@ethersproject/networks@npm:5.7.1"
+"@ethersproject/networks@npm:5.8.0, @ethersproject/networks@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/networks@npm:5.8.0"
   dependencies:
-    "@ethersproject/logger": ^5.7.0
-  checksum: 0339f312304c17d9a0adce550edb825d4d2c8c9468c1634c44172c67a9ed256f594da62c4cda5c3837a0f28b7fabc03aca9b492f68ff1fdad337ee861b27bd5d
+    "@ethersproject/logger": ^5.8.0
+  checksum: b1d43fdab13e32be74b5547968c7e54786915a1c3543025c628f634872038750171bef15db0cf42a27e568175b185ac9c185a9aae8f93839452942c5a867c908
   languageName: node
   linkType: hard
 
-"@ethersproject/pbkdf2@npm:5.7.0, @ethersproject/pbkdf2@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/pbkdf2@npm:5.7.0"
+"@ethersproject/pbkdf2@npm:5.8.0, @ethersproject/pbkdf2@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/pbkdf2@npm:5.8.0"
   dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/sha2": ^5.7.0
-  checksum: b895adb9e35a8a127e794f7aadc31a2424ef355a70e51cde10d457e3e888bb8102373199a540cf61f2d6b9a32e47358f9c65b47d559f42bf8e596b5fd67901e9
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/sha2": ^5.8.0
+  checksum: 79e06ec6063e745a714c7c3f8ecfb7a8d2db2d19d45ad0e84e59526f685a2704f06e8c8fbfaf3aca85d15037bead7376d704529aac783985e1ff7b90c2d6e714
   languageName: node
   linkType: hard
 
-"@ethersproject/properties@npm:5.7.0, @ethersproject/properties@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/properties@npm:5.7.0"
+"@ethersproject/properties@npm:5.8.0, @ethersproject/properties@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/properties@npm:5.8.0"
   dependencies:
-    "@ethersproject/logger": ^5.7.0
-  checksum: 6ab0ccf0c3aadc9221e0cdc5306ce6cd0df7f89f77d77bccdd1277182c9ead0202cd7521329ba3acde130820bf8af299e17cf567d0d497c736ee918207bbf59f
+    "@ethersproject/logger": ^5.8.0
+  checksum: 2bb0369a3c25a7c1999e990f73a9db149a5e514af253e3945c7728eaea5d864144da6a81661c0c414b97be75db7fb15c34f719169a3adb09e585a3286ea78b9c
   languageName: node
   linkType: hard
 
-"@ethersproject/providers@npm:5.7.2":
-  version: 5.7.2
-  resolution: "@ethersproject/providers@npm:5.7.2"
+"@ethersproject/providers@npm:5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/providers@npm:5.8.0"
   dependencies:
-    "@ethersproject/abstract-provider": ^5.7.0
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/base64": ^5.7.0
-    "@ethersproject/basex": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/hash": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/networks": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/random": ^5.7.0
-    "@ethersproject/rlp": ^5.7.0
-    "@ethersproject/sha2": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-    "@ethersproject/web": ^5.7.0
+    "@ethersproject/abstract-provider": ^5.8.0
+    "@ethersproject/abstract-signer": ^5.8.0
+    "@ethersproject/address": ^5.8.0
+    "@ethersproject/base64": ^5.8.0
+    "@ethersproject/basex": ^5.8.0
+    "@ethersproject/bignumber": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/constants": ^5.8.0
+    "@ethersproject/hash": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/networks": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+    "@ethersproject/random": ^5.8.0
+    "@ethersproject/rlp": ^5.8.0
+    "@ethersproject/sha2": ^5.8.0
+    "@ethersproject/strings": ^5.8.0
+    "@ethersproject/transactions": ^5.8.0
+    "@ethersproject/web": ^5.8.0
     bech32: 1.1.4
-    ws: 7.4.6
-  checksum: 1754c731a5ca6782ae9677f4a9cd8b6246c4ef21a966c9a01b133750f3c578431ec43ec254e699969c4a0f87e84463ded50f96b415600aabd37d2056aee58c19
+    ws: 8.18.0
+  checksum: 2970ee03fe61bc941555b57075d4a12fbb6342ee56181ad75250a75e9418403e85821bbea1b6e17b25ef35e9eaa1c2b2c564dad7d20af2c1f28ba6db9d0c7ce3
   languageName: node
   linkType: hard
 
-"@ethersproject/random@npm:5.7.0, @ethersproject/random@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/random@npm:5.7.0"
+"@ethersproject/random@npm:5.8.0, @ethersproject/random@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/random@npm:5.8.0"
   dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-  checksum: 017829c91cff6c76470852855108115b0b52c611b6be817ed1948d56ba42d6677803ec2012aa5ae298a7660024156a64c11fcf544e235e239ab3f89f0fff7345
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+  checksum: c3bec10516b433eca7ddbd5d97cf2c24153f8fb9615225ea2e3b7fab95a6d6434ab8af55ce55527c3aeb00546ee4363a43aecdc0b5a9970a207ab1551783ddef
   languageName: node
   linkType: hard
 
-"@ethersproject/rlp@npm:5.7.0, @ethersproject/rlp@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/rlp@npm:5.7.0"
+"@ethersproject/rlp@npm:5.8.0, @ethersproject/rlp@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/rlp@npm:5.8.0"
   dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-  checksum: bce165b0f7e68e4d091c9d3cf47b247cac33252df77a095ca4281d32d5eeaaa3695d9bc06b2b057c5015353a68df89f13a4a54a72e888e4beeabbe56b15dda6e
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+  checksum: 9d6f646072b3dd61de993210447d35744a851d24d4fe6262856e372f47a1e9d90976031a9fa28c503b1a4f39dd5ab7c20fc9b651b10507a09b40a33cb04a19f1
   languageName: node
   linkType: hard
 
-"@ethersproject/sha2@npm:5.7.0, @ethersproject/sha2@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/sha2@npm:5.7.0"
+"@ethersproject/sha2@npm:5.8.0, @ethersproject/sha2@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/sha2@npm:5.8.0"
   dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
     hash.js: 1.1.7
-  checksum: 09321057c022effbff4cc2d9b9558228690b5dd916329d75c4b1ffe32ba3d24b480a367a7cc92d0f0c0b1c896814d03351ae4630e2f1f7160be2bcfbde435dbc
+  checksum: ef8916e3033502476fba9358ba1993722ac3bb99e756d5681e4effa3dfa0f0bf0c29d3fa338662830660b45dd359cccb06ba40bc7b62cfd44f4a177b25829404
   languageName: node
   linkType: hard
 
-"@ethersproject/signing-key@npm:5.7.0, @ethersproject/signing-key@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/signing-key@npm:5.7.0"
+"@ethersproject/signing-key@npm:5.8.0, @ethersproject/signing-key@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/signing-key@npm:5.8.0"
   dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
     bn.js: ^5.2.1
-    elliptic: 6.5.4
+    elliptic: 6.6.1
     hash.js: 1.1.7
-  checksum: 8f8de09b0aac709683bbb49339bc0a4cd2f95598f3546436c65d6f3c3a847ffa98e06d35e9ed2b17d8030bd2f02db9b7bd2e11c5cf8a71aad4537487ab4cf03a
+  checksum: 8c07741bc8275568130d97da5d37535c813c842240d0b3409d5e057321595eaf65660c207abdee62e2d7ba225d9b82f0b711ac0324c8c9ceb09a815b231b9f55
   languageName: node
   linkType: hard
 
-"@ethersproject/solidity@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/solidity@npm:5.7.0"
+"@ethersproject/solidity@npm:5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/solidity@npm:5.8.0"
   dependencies:
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/sha2": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-  checksum: 9a02f37f801c96068c3e7721f83719d060175bc4e80439fe060e92bd7acfcb6ac1330c7e71c49f4c2535ca1308f2acdcb01e00133129aac00581724c2d6293f3
+    "@ethersproject/bignumber": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/keccak256": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/sha2": ^5.8.0
+    "@ethersproject/strings": ^5.8.0
+  checksum: 305166f3f8e8c2f5ad7b0b03ab96d52082fc79b5136601175e1c76d7abd8fd8e3e4b56569dea745dfa2b7fcbfd180c5d824b03fea7e08dd53d515738a35e51dd
   languageName: node
   linkType: hard
 
-"@ethersproject/strings@npm:5.7.0, @ethersproject/strings@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/strings@npm:5.7.0"
+"@ethersproject/strings@npm:5.8.0, @ethersproject/strings@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/strings@npm:5.8.0"
   dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-  checksum: 5ff78693ae3fdf3cf23e1f6dc047a61e44c8197d2408c42719fef8cb7b7b3613a4eec88ac0ed1f9f5558c74fe0de7ae3195a29ca91a239c74b9f444d8e8b50df
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/constants": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+  checksum: 997396cf1b183ae66ebfd97b9f98fd50415489f9246875e7769e57270ffa1bffbb62f01430eaac3a0c9cb284e122040949efe632a0221012ee47de252a44a483
   languageName: node
   linkType: hard
 
-"@ethersproject/transactions@npm:5.7.0, @ethersproject/transactions@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/transactions@npm:5.7.0"
+"@ethersproject/transactions@npm:5.8.0, @ethersproject/transactions@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/transactions@npm:5.8.0"
   dependencies:
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/rlp": ^5.7.0
-    "@ethersproject/signing-key": ^5.7.0
-  checksum: a31b71996d2b283f68486241bff0d3ea3f1ba0e8f1322a8fffc239ccc4f4a7eb2ea9994b8fd2f093283fd75f87bae68171e01b6265261f821369aca319884a79
+    "@ethersproject/address": ^5.8.0
+    "@ethersproject/bignumber": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/constants": ^5.8.0
+    "@ethersproject/keccak256": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+    "@ethersproject/rlp": ^5.8.0
+    "@ethersproject/signing-key": ^5.8.0
+  checksum: e867516ccc692c3642bfbd34eab6d2acecabb3b964d8e1cced8e450ec4fa490bcf2513efb6252637bc3157ecd5e0250dadd1a08d3ec3150c14478b9ec7715570
   languageName: node
   linkType: hard
 
-"@ethersproject/units@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/units@npm:5.7.0"
+"@ethersproject/units@npm:5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/units@npm:5.8.0"
   dependencies:
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-  checksum: 304714f848cd32e57df31bf545f7ad35c2a72adae957198b28cbc62166daa929322a07bff6e9c9ac4577ab6aa0de0546b065ed1b2d20b19e25748b7d475cb0fc
+    "@ethersproject/bignumber": ^5.8.0
+    "@ethersproject/constants": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+  checksum: cc7180c85f695449c20572602971145346fc5c169ee32f23d79ac31cc8c9c66a2049e3ac852b940ddccbe39ab1db3b81e3e093b604d9ab7ab27639ecb933b270
   languageName: node
   linkType: hard
 
-"@ethersproject/wallet@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/wallet@npm:5.7.0"
+"@ethersproject/wallet@npm:5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/wallet@npm:5.8.0"
   dependencies:
-    "@ethersproject/abstract-provider": ^5.7.0
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/hash": ^5.7.0
-    "@ethersproject/hdnode": ^5.7.0
-    "@ethersproject/json-wallets": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/random": ^5.7.0
-    "@ethersproject/signing-key": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-    "@ethersproject/wordlists": ^5.7.0
-  checksum: a4009bf7331eddab38e3015b5e9101ef92de7f705b00a6196b997db0e5635b6d83561674d46c90c6f77b87c0500fe4a6b0183ba13749efc22db59c99deb82fbd
+    "@ethersproject/abstract-provider": ^5.8.0
+    "@ethersproject/abstract-signer": ^5.8.0
+    "@ethersproject/address": ^5.8.0
+    "@ethersproject/bignumber": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/hash": ^5.8.0
+    "@ethersproject/hdnode": ^5.8.0
+    "@ethersproject/json-wallets": ^5.8.0
+    "@ethersproject/keccak256": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+    "@ethersproject/random": ^5.8.0
+    "@ethersproject/signing-key": ^5.8.0
+    "@ethersproject/transactions": ^5.8.0
+    "@ethersproject/wordlists": ^5.8.0
+  checksum: d2921c3212c30a49048e0cba7a8287e0d53a5346ad5a15d46d9932991dc54e541a3da063c47addc1347a4b65142d7239f7056c8716d6f85c8ec4a1bf6b5d2f69
   languageName: node
   linkType: hard
 
-"@ethersproject/web@npm:5.7.1, @ethersproject/web@npm:^5.7.0":
-  version: 5.7.1
-  resolution: "@ethersproject/web@npm:5.7.1"
+"@ethersproject/web@npm:5.8.0, @ethersproject/web@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/web@npm:5.8.0"
   dependencies:
-    "@ethersproject/base64": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-  checksum: 7028c47103f82fd2e2c197ce0eecfacaa9180ffeec7de7845b1f4f9b19d84081b7a48227aaddde05a4aaa526af574a9a0ce01cc0fc75e3e371f84b38b5b16b2b
+    "@ethersproject/base64": ^5.8.0
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+    "@ethersproject/strings": ^5.8.0
+  checksum: d8ca89bde8777ed1eec81527f8a989b939b4625b2f6c275eea90031637a802ad68bf46911fdd43c5e84ea2962b8a3cb4801ab51f5393ae401a163c17c774123f
   languageName: node
   linkType: hard
 
-"@ethersproject/wordlists@npm:5.7.0, @ethersproject/wordlists@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/wordlists@npm:5.7.0"
+"@ethersproject/wordlists@npm:5.8.0, @ethersproject/wordlists@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/wordlists@npm:5.8.0"
   dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/hash": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-  checksum: 30eb6eb0731f9ef5faa44bf9c0c6e950bcaaef61e4d2d9ce0ae6d341f4e2d6d1f4ab4f8880bfce03b7aac4b862fb740e1421170cfbf8e2aafc359277d49e6e97
+    "@ethersproject/bytes": ^5.8.0
+    "@ethersproject/hash": ^5.8.0
+    "@ethersproject/logger": ^5.8.0
+    "@ethersproject/properties": ^5.8.0
+    "@ethersproject/strings": ^5.8.0
+  checksum: ba24300927a3c9cb85ae8ace84a6be73f3c43aac6eab7a3abe58a7dfd3b168caf3f01a4528efa8193e269dd3d5efe9d4533bdf3b29d5c55743edcb2e864d25d9
   languageName: node
   linkType: hard
 
@@ -2305,7 +2305,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.53.0
     eslint: ^8.34.0
     eslint-config-prettier: ^8.6.0
-    ethers: ^5.7.2
+    ethers: ^5.7
     husky: ^8.0.2
     jest: ^29.4.2
     mento-router-ts: ^0.2.0
@@ -3475,9 +3475,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:6.5.4":
-  version: 6.5.4
-  resolution: "elliptic@npm:6.5.4"
+"elliptic@npm:6.6.1":
+  version: 6.6.1
+  resolution: "elliptic@npm:6.6.1"
   dependencies:
     bn.js: ^4.11.9
     brorand: ^1.1.0
@@ -3486,7 +3486,7 @@ __metadata:
     inherits: ^2.0.4
     minimalistic-assert: ^1.0.1
     minimalistic-crypto-utils: ^1.0.1
-  checksum: d56d21fd04e97869f7ffcc92e18903b9f67f2d4637a23c860492fbbff5a3155fd9ca0184ce0c865dd6eb2487d234ce9551335c021c376cd2d3b7cb749c7d10f4
+  checksum: 27b14a52f68bbbc0720da259f712cb73e953f6d2047958cd02fb0d0ade2e83849dc39fb4af630889c67df8817e24237428cf59c4f4c07700f755b401149a7375
   languageName: node
   linkType: hard
 
@@ -3807,41 +3807,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:^5.7.2":
-  version: 5.7.2
-  resolution: "ethers@npm:5.7.2"
+"ethers@npm:^5.7":
+  version: 5.8.0
+  resolution: "ethers@npm:5.8.0"
   dependencies:
-    "@ethersproject/abi": 5.7.0
-    "@ethersproject/abstract-provider": 5.7.0
-    "@ethersproject/abstract-signer": 5.7.0
-    "@ethersproject/address": 5.7.0
-    "@ethersproject/base64": 5.7.0
-    "@ethersproject/basex": 5.7.0
-    "@ethersproject/bignumber": 5.7.0
-    "@ethersproject/bytes": 5.7.0
-    "@ethersproject/constants": 5.7.0
-    "@ethersproject/contracts": 5.7.0
-    "@ethersproject/hash": 5.7.0
-    "@ethersproject/hdnode": 5.7.0
-    "@ethersproject/json-wallets": 5.7.0
-    "@ethersproject/keccak256": 5.7.0
-    "@ethersproject/logger": 5.7.0
-    "@ethersproject/networks": 5.7.1
-    "@ethersproject/pbkdf2": 5.7.0
-    "@ethersproject/properties": 5.7.0
-    "@ethersproject/providers": 5.7.2
-    "@ethersproject/random": 5.7.0
-    "@ethersproject/rlp": 5.7.0
-    "@ethersproject/sha2": 5.7.0
-    "@ethersproject/signing-key": 5.7.0
-    "@ethersproject/solidity": 5.7.0
-    "@ethersproject/strings": 5.7.0
-    "@ethersproject/transactions": 5.7.0
-    "@ethersproject/units": 5.7.0
-    "@ethersproject/wallet": 5.7.0
-    "@ethersproject/web": 5.7.1
-    "@ethersproject/wordlists": 5.7.0
-  checksum: b7c08cf3e257185a7946117dbbf764433b7ba0e77c27298dec6088b3bc871aff711462b0621930c56880ff0a7ceb8b1d3a361ffa259f93377b48e34107f62553
+    "@ethersproject/abi": 5.8.0
+    "@ethersproject/abstract-provider": 5.8.0
+    "@ethersproject/abstract-signer": 5.8.0
+    "@ethersproject/address": 5.8.0
+    "@ethersproject/base64": 5.8.0
+    "@ethersproject/basex": 5.8.0
+    "@ethersproject/bignumber": 5.8.0
+    "@ethersproject/bytes": 5.8.0
+    "@ethersproject/constants": 5.8.0
+    "@ethersproject/contracts": 5.8.0
+    "@ethersproject/hash": 5.8.0
+    "@ethersproject/hdnode": 5.8.0
+    "@ethersproject/json-wallets": 5.8.0
+    "@ethersproject/keccak256": 5.8.0
+    "@ethersproject/logger": 5.8.0
+    "@ethersproject/networks": 5.8.0
+    "@ethersproject/pbkdf2": 5.8.0
+    "@ethersproject/properties": 5.8.0
+    "@ethersproject/providers": 5.8.0
+    "@ethersproject/random": 5.8.0
+    "@ethersproject/rlp": 5.8.0
+    "@ethersproject/sha2": 5.8.0
+    "@ethersproject/signing-key": 5.8.0
+    "@ethersproject/solidity": 5.8.0
+    "@ethersproject/strings": 5.8.0
+    "@ethersproject/transactions": 5.8.0
+    "@ethersproject/units": 5.8.0
+    "@ethersproject/wallet": 5.8.0
+    "@ethersproject/web": 5.8.0
+    "@ethersproject/wordlists": 5.8.0
+  checksum: fb107bf28dc3aedde4729f9553be066c699e0636346c095b4deeb5349a0c0c8538f48a58b5c8cbefced008706919739c5f7b8f4dd506bb471a31edee18cda228
   languageName: node
   linkType: hard
 
@@ -6514,18 +6514,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:7.4.6":
-  version: 7.4.6
-  resolution: "ws@npm:7.4.6"
+"ws@npm:8.18.0":
+  version: 8.18.0
+  resolution: "ws@npm:8.18.0"
   peerDependencies:
     bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
+    utf-8-validate: ">=5.0.2"
   peerDependenciesMeta:
     bufferutil:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 3a990b32ed08c72070d5e8913e14dfcd831919205be52a3ff0b4cdd998c8d554f167c9df3841605cde8b11d607768cacab3e823c58c96a5c08c987e093eb767a
+  checksum: 91d4d35bc99ff6df483bdf029b9ea4bfd7af1f16fc91231a96777a63d263e1eabf486e13a2353970efc534f9faa43bdbf9ee76525af22f4752cbc5ebda333975
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This change updates the cached list of tradeable pairs to include the newly launched tokens as part of [CGP 178](https://github.com/celo-org/governance/blob/main/CGPs/cgp-0178.md)

Please note: This only adds the pairs on Alfajores, a follow up PR will be created for the mainnet pairs once the proposal has been submitted and passed on mainnet.

### Other changes

- Loosened the version range for ethers. The providers sub module, which is used by the tradeable pairs script, is in newer versions
