### PR TITLE
refactor: Remove fiat symbol mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "ethers": "^6.13.4",
-    "ethers-v5": "npm:ethers@^5.7.2",
+    "ethers-v5": "npm:ethers@^5.7",
     "viem": "^2.21.44"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^6.13.4
         version: 6.13.4
       ethers-v5:
-        specifier: npm:ethers@^5.7.2
+        specifier: npm:ethers@^5.7
         version: ethers@5.7.2
       viem:
         specifier: ^2.21.44

--- a/src/constants/stableTokenMetadata.ts
+++ b/src/constants/stableTokenMetadata.ts
@@ -10,22 +10,3 @@ export const STABLE_TOKEN_SYMBOLS = {
 } as const
 
 export type StableTokenSymbol = keyof typeof STABLE_TOKEN_SYMBOLS
-
-export const STABLE_TOKEN_FIAT_MAPPING: Record<StableTokenSymbol, string> = {
-  cUSD: 'USD',
-  cEUR: 'EUR',
-  cREAL: 'BRL',
-  cKES: 'KES',
-  PUSO: 'PHP',
-  cCOP: 'COP',
-  eXOF: 'XOF',
-  cGHS: 'GHS',
-} as const
-
-export function getFiatTicker(symbol: StableTokenSymbol): string {
-  const ticker = STABLE_TOKEN_FIAT_MAPPING[symbol]
-  if (!ticker) {
-    throw new Error(`No fiat ticker found for token symbol: ${symbol}`)
-  }
-  return ticker
-}

--- a/src/services/stableTokenService.ts
+++ b/src/services/stableTokenService.ts
@@ -1,10 +1,5 @@
 import { RESERVE_ABI } from '../abis'
-import {
-  getContractAddress,
-  getFiatTicker,
-  RESERVE,
-  StableTokenSymbol,
-} from '../constants'
+import { getContractAddress, RESERVE } from '../constants'
 import { ProviderAdapter, StableToken } from '../types'
 import { SupplyAdjustmentService } from './supplyAdjustmentService'
 import { TokenMetadataService } from './tokenMetadataService'
@@ -40,7 +35,6 @@ export class StableTokenService {
         address,
         ...metadata,
         totalSupply,
-        fiatTicker: getFiatTicker(metadata.symbol as StableTokenSymbol),
       }
 
       const adjustedSupply =

--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -9,7 +9,6 @@ export interface BaseToken {
 
 export interface StableToken extends BaseToken {
   totalSupply: string
-  fiatTicker: string
 }
 
 export type CollateralAsset = BaseToken

--- a/tests/integration/services/supplyAdjustmentService.test.ts
+++ b/tests/integration/services/supplyAdjustmentService.test.ts
@@ -32,7 +32,6 @@ describe.only('SupplyAdjustmentService Integration Tests', () => {
         totalSupply: cusdOnChainSupply,
         name: 'Celo Dollar',
         decimals: 18,
-        fiatTicker: 'USD',
       }
 
       const adjustedSupply = await supplyAdjustmentService.getAdjustedSupply(


### PR DESCRIPTION
### Description

Remove fiat mapping and moved to the API where it is used.
