### PR TITLE
feat: new trading pairs on Alfajores

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/src/constants/tradablePairs.44787.ts
+++ b/src/constants/tradablePairs.44787.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on 2025-06-24T11:08:55.032Z
+// Generated on 2025-06-26T16:12:28.767Z
 
 import { TradablePairWithSpread } from './tradablePairs'
 
@@ -27,11 +27,43 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.05,
+      "totalSpreadPercent": 0,
       "hops": [
         {
           "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-cUSD",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
+      },
+      {
+        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+        "symbol": "cUSD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0,
+      "hops": [
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
         }
       ]
     }
@@ -59,11 +91,55 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.05,
+      "totalSpreadPercent": 0,
       "hops": [
         {
           "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-USDC",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
+      },
+      {
+        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+        "symbol": "USDC"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0,
+      "hops": [
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
         }
       ]
     }
@@ -99,125 +175,29 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.099975,
+      "totalSpreadPercent": 0,
       "hops": [
         {
           "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
           "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         }
       ]
     }
   },
   {
-    "id": "CELO-cREAL",
-    "assets": [
-      {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
-        "symbol": "cREAL"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-        "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.25,
-      "hops": [
-        {
-          "exchangeId": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "USDC-cREAL",
-    "assets": [
-      {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
-      },
-      {
-        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
-        "symbol": "cREAL"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-        "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.25,
-      "hops": [
-        {
-          "exchangeId": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "USDC-cEUR",
-    "assets": [
-      {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
-      },
-      {
-        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-        "symbol": "cEUR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-        "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.25,
-      "hops": [
-        {
-          "exchangeId": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-cUSD",
+    "id": "BridgedUSDC-USDT",
     "assets": [
       {
         "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
         "symbol": "BridgedUSDC"
       },
       {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
+        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+        "symbol": "USDT"
       }
     ],
     "path": [
@@ -228,14 +208,354 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x87D61dA3d668797786D73BC674F053f87111570d"
         ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.25,
+      "totalSpreadPercent": 0,
       "hops": [
         {
           "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "cAUD-cUSD",
+    "assets": [
+      {
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
+      },
+      {
+        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+        "symbol": "cUSD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cUSD",
+    "assets": [
+      {
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+        "symbol": "cUSD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cAUD",
+    "assets": [
+      {
+        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cCAD",
+    "assets": [
+      {
+        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-cAUD",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
+      },
+      {
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-cCAD",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
+      },
+      {
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDT-cAUD",
+    "assets": [
+      {
+        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+        "symbol": "USDT"
+      },
+      {
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDT-cCAD",
+    "assets": [
+      {
+        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+        "symbol": "USDT"
+      },
+      {
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
         }
       ]
     }
@@ -273,38 +593,6 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "CELO-cEUR",
-    "assets": [
-      {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-        "symbol": "cEUR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-        "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.25,
-      "hops": [
-        {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
     "id": "CELO-USDC",
     "assets": [
       {
@@ -319,31 +607,75 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
         ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.299875,
+      "totalSpreadPercent": 0.25,
       "hops": [
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        },
         {
           "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
           "spreadPercent": 0.25
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-CELO",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
+      },
+      {
+        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+        "symbol": "CELO"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.25,
+      "hops": [
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
         },
         {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
         }
       ]
     }
@@ -363,253 +695,45 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
         ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
-        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.299875,
+      "totalSpreadPercent": 0.25,
       "hops": [
+        {
+          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "spreadPercent": 0
+        },
         {
           "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
           "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
         }
       ]
     }
   },
   {
-    "id": "cREAL-cUSD",
-    "assets": [
-      {
-        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
-        "symbol": "cREAL"
-      },
-      {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-        "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.299875,
-      "hops": [
-        {
-          "exchangeId": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-USDC",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.299875,
-      "hops": [
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        },
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-USDT",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
-        "symbol": "USDT"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.299875,
-      "hops": [
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
-        }
-      ]
-    }
-  },
-  {
-    "id": "cEUR-cUSD",
-    "assets": [
-      {
-        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-        "symbol": "cEUR"
-      },
-      {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-        "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.299875,
-      "hops": [
-        {
-          "exchangeId": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cUSD",
-    "assets": [
-      {
-        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.3,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cUSD",
+    "id": "cAUD-cCAD",
     "assets": [
       {
         "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
         "symbol": "cAUD"
       },
       {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
       }
     ],
     "path": [
@@ -620,46 +744,26 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
         ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.3,
-      "hops": [
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCOP-cUSD",
-    "assets": [
-      {
-        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
-        "symbol": "cCOP"
       },
       {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
-      }
-    ],
-    "path": [
-      {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.3,
+      "totalSpreadPercent": 0.299775,
       "hops": [
         {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
         }
       ]
     }
@@ -723,38 +827,6 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       "hops": [
         {
           "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCAD-cUSD",
-    "assets": [
-      {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
-      },
-      {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.3,
-      "hops": [
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
           "spreadPercent": 0.3
         }
       ]
@@ -825,6 +897,630 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
+    "id": "PUSO-cUSD",
+    "assets": [
+      {
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+        "symbol": "cUSD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCOP-cUSD",
+    "assets": [
+      {
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+        "symbol": "cUSD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cREAL-cUSD",
+    "assets": [
+      {
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
+      },
+      {
+        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+        "symbol": "cUSD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cGBP",
+    "assets": [
+      {
+        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+        "symbol": "cGBP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-cGBP",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
+      },
+      {
+        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+        "symbol": "cGBP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDT-cGBP",
+    "assets": [
+      {
+        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+        "symbol": "USDT"
+      },
+      {
+        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+        "symbol": "cGBP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cZAR",
+    "assets": [
+      {
+        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-cZAR",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
+      },
+      {
+        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDT-cZAR",
+    "assets": [
+      {
+        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+        "symbol": "USDT"
+      },
+      {
+        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cJPY",
+    "assets": [
+      {
+        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
+        "symbol": "cJPY"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-cJPY",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
+      },
+      {
+        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
+        "symbol": "cJPY"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDT-cJPY",
+    "assets": [
+      {
+        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+        "symbol": "USDT"
+      },
+      {
+        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
+        "symbol": "cJPY"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cCHF",
+    "assets": [
+      {
+        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
+        "symbol": "cCHF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-cCHF",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
+      },
+      {
+        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
+        "symbol": "cCHF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDT-cCHF",
+    "assets": [
+      {
+        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+        "symbol": "USDT"
+      },
+      {
+        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
+        "symbol": "cCHF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
     "id": "PUSO-USDC",
     "assets": [
       {
@@ -855,58 +1551,14 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
           "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "USDC-cAUD",
-    "assets": [
-      {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
-      },
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.34985,
-      "hops": [
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
           "spreadPercent": 0.3
         }
       ]
@@ -943,11 +1595,11 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
           "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
@@ -957,15 +1609,15 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "USDC-cGBP",
+    "id": "USDC-cREAL",
     "assets": [
       {
         "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
         "symbol": "USDC"
       },
       {
-        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
-        "symbol": "cGBP"
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
       }
     ],
     "path": [
@@ -979,198 +1631,154 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "USDC-cZAR",
+    "id": "BridgedUSDC-PUSO",
     "assets": [
       {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
       },
       {
-        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
-        "symbol": "cZAR"
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
         },
         {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "USDC-cCAD",
+    "id": "BridgedUSDC-cCOP",
     "assets": [
       {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
       },
       {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
         },
         {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "USDC-cJPY",
+    "id": "BridgedUSDC-cREAL",
     "assets": [
       {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
       },
       {
-        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
-        "symbol": "cJPY"
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
         },
         {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "USDC-cCHF",
-    "assets": [
-      {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
-      },
-      {
-        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
-        "symbol": "cCHF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.34985,
-      "hops": [
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
@@ -1207,58 +1815,14 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
           "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "USDT-cAUD",
-    "assets": [
-      {
-        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
-        "symbol": "USDT"
-      },
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.34985,
-      "hops": [
-        {
-          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
           "spreadPercent": 0.3
         }
       ]
@@ -1295,11 +1859,11 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
           "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
@@ -1309,15 +1873,15 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "USDT-cGBP",
+    "id": "USDT-cREAL",
     "assets": [
       {
         "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
         "symbol": "USDT"
       },
       {
-        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
-        "symbol": "cGBP"
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
       }
     ],
     "path": [
@@ -1331,77 +1895,77 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "USDT-cZAR",
+    "id": "CELO-cAUD",
     "assets": [
       {
-        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
-        "symbol": "USDT"
+        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+        "symbol": "CELO"
       },
       {
-        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
-        "symbol": "cZAR"
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.399625,
       "hops": [
         {
-          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
         },
         {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
         }
       ]
     }
   },
   {
-    "id": "USDT-cCAD",
+    "id": "CELO-cCAD",
     "assets": [
       {
-        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
-        "symbol": "USDT"
+        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+        "symbol": "CELO"
       },
       {
         "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
@@ -1411,10 +1975,10 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
         ]
       },
       {
@@ -1427,25 +1991,201 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.399625,
       "hops": [
         {
-          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
         },
         {
           "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
+          "spreadPercent": 0.15
         }
       ]
     }
   },
   {
-    "id": "USDT-cJPY",
+    "id": "cAUD-cGBP",
     "assets": [
       {
-        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
-        "symbol": "USDT"
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
+      },
+      {
+        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+        "symbol": "cGBP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cGBP",
+    "assets": [
+      {
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+        "symbol": "cGBP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cAUD-cZAR",
+    "assets": [
+      {
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
+      },
+      {
+        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cZAR",
+    "assets": [
+      {
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cAUD-cJPY",
+    "assets": [
+      {
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
       },
       {
         "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
@@ -1455,12 +2195,48 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
         ]
       },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cJPY",
+    "assets": [
+      {
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
+        "symbol": "cJPY"
+      }
+    ],
+    "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
@@ -1468,28 +2244,36 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
         ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.44955,
       "hops": [
-        {
-          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
-        },
         {
           "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
           "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
         }
       ]
     }
   },
   {
-    "id": "USDT-cCHF",
+    "id": "cAUD-cCHF",
     "assets": [
       {
-        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
-        "symbol": "USDT"
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
       },
       {
         "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
@@ -1499,12 +2283,48 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
         ]
       },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cCHF",
+    "assets": [
+      {
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
+        "symbol": "cCHF"
+      }
+    ],
+    "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
@@ -1512,204 +2332,124 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
         ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "PUSO-cAUD",
+    "assets": [
+      {
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "CELO-USDC",
+    "id": "cAUD-cCOP",
     "assets": [
       {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
       },
       {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-        "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-        "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.499375,
-      "hops": [
-        {
-          "exchangeId": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "CELO-USDC",
-    "assets": [
-      {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-        "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-        "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.499375,
-      "hops": [
-        {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-CELO",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.499375,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
         },
         {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "cREAL-cUSD",
+    "id": "cAUD-cREAL",
     "assets": [
       {
-        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
-        "symbol": "cREAL"
-      },
-      {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-        "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.499375,
-      "hops": [
-        {
-          "exchangeId": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "cEUR-cREAL",
-    "assets": [
-      {
-        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-        "symbol": "cEUR"
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
       },
       {
         "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
@@ -1719,161 +2459,129 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-        "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-        "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.499375,
-      "hops": [
-        {
-          "exchangeId": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "cEUR-cREAL",
-    "assets": [
-      {
-        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-        "symbol": "cEUR"
-      },
-      {
-        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
-        "symbol": "cREAL"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-        "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-        "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.499375,
-      "hops": [
-        {
-          "exchangeId": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "cEUR-cUSD",
-    "assets": [
-      {
-        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-        "symbol": "cEUR"
-      },
-      {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-        "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.499375,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-          "spreadPercent": 0.25
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
         },
         {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "BridgedUSDC-cEUR",
+    "id": "PUSO-cCAD",
     "assets": [
       {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
       },
       {
-        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-        "symbol": "cEUR"
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
         "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.5,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
-          "spreadPercent": 0.5
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
         }
       ]
     }
   },
   {
-    "id": "BridgedUSDC-cREAL",
+    "id": "cCAD-cCOP",
     "assets": [
       {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cREAL",
+    "assets": [
+      {
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
       },
       {
         "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
@@ -1883,19 +2591,31 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
         "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.5,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
-          "spreadPercent": 0.5
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
         }
       ]
     }
@@ -1933,6 +2653,346 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
+    "id": "cEUR-cUSD",
+    "assets": [
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      },
+      {
+        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+        "symbol": "cUSD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cEUR",
+    "assets": [
+      {
+        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-cEUR",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
+      },
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDT-cEUR",
+    "assets": [
+      {
+        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+        "symbol": "USDT"
+      },
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cGBP",
+    "assets": [
+      {
+        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+        "symbol": "cGBP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.54925,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cZAR",
+    "assets": [
+      {
+        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.54925,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cJPY",
+    "assets": [
+      {
+        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
+        "symbol": "cJPY"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.54925,
+      "hops": [
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cCHF",
+    "assets": [
+      {
+        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
+        "symbol": "cCHF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.54925,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
+        }
+      ]
+    }
+  },
+  {
     "id": "CELO-PUSO",
     "assets": [
       {
@@ -1947,48 +3007,12 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
         ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "CELO-cAUD",
-    "assets": [
-      {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
       },
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      }
-    ],
-    "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
@@ -1996,26 +3020,18 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
         ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
       }
     ],
     "spreadData": {
       "totalSpreadPercent": 0.54925,
       "hops": [
         {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
         }
       ]
     }
@@ -2065,15 +3081,15 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "CELO-cGBP",
+    "id": "CELO-cREAL",
     "assets": [
       {
         "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
         "symbol": "CELO"
       },
       {
-        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
-        "symbol": "cGBP"
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
       }
     ],
     "path": [
@@ -2087,10 +3103,10 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
         ]
       }
     ],
@@ -2102,1327 +3118,7 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
           "spreadPercent": 0.25
         },
         {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "CELO-cZAR",
-    "assets": [
-      {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "CELO-cCAD",
-    "assets": [
-      {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "CELO-cJPY",
-    "assets": [
-      {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
-        "symbol": "cJPY"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "CELO-cCHF",
-    "assets": [
-      {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
-        "symbol": "cCHF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-PUSO",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
-        "symbol": "PUSO"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-cAUD",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-cCOP",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
-        "symbol": "cCOP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-cGBP",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
-        "symbol": "cGBP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-cZAR",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-cCAD",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-cJPY",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
-        "symbol": "cJPY"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-cCHF",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
-        "symbol": "cCHF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cAUD",
-    "assets": [
-      {
-        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cCOP",
-    "assets": [
-      {
-        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
-        "symbol": "cCOP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cGBP",
-    "assets": [
-      {
-        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
-        "symbol": "cGBP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cZAR",
-    "assets": [
-      {
-        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cCAD",
-    "assets": [
-      {
-        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cJPY",
-    "assets": [
-      {
-        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
-        "symbol": "cJPY"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cCHF",
-    "assets": [
-      {
-        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
-        "symbol": "cCHF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cCOP",
-    "assets": [
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
-        "symbol": "cCOP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cGBP",
-    "assets": [
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
-        "symbol": "cGBP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cZAR",
-    "assets": [
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cCAD",
-    "assets": [
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cJPY",
-    "assets": [
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
-        "symbol": "cJPY"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cCHF",
-    "assets": [
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
-        "symbol": "cCHF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCOP-cGBP",
-    "assets": [
-      {
-        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
-        "symbol": "cCOP"
-      },
-      {
-        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
-        "symbol": "cGBP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCOP-cZAR",
-    "assets": [
-      {
-        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
-        "symbol": "cCOP"
-      },
-      {
-        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCAD-cCOP",
-    "assets": [
-      {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
-      },
-      {
-        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
-        "symbol": "cCOP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCOP-cJPY",
-    "assets": [
-      {
-        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
-        "symbol": "cCOP"
-      },
-      {
-        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
-        "symbol": "cJPY"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCHF-cCOP",
-    "assets": [
-      {
-        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
-        "symbol": "cCHF"
-      },
-      {
-        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
-        "symbol": "cCOP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
@@ -3467,50 +3163,6 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
         },
         {
           "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCAD-cGBP",
-    "assets": [
-      {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
-      },
-      {
-        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
-        "symbol": "cGBP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
           "spreadPercent": 0.3
         }
       ]
@@ -3605,32 +3257,32 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "cCAD-cZAR",
+    "id": "PUSO-cGBP",
     "assets": [
       {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
       },
       {
-        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
-        "symbol": "cZAR"
+        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+        "symbol": "cGBP"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
         ]
       }
     ],
@@ -3638,11 +3290,99 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
           "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCOP-cGBP",
+    "assets": [
+      {
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+        "symbol": "cGBP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cGBP-cREAL",
+    "assets": [
+      {
+        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+        "symbol": "cGBP"
+      },
+      {
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
@@ -3737,32 +3477,32 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "cCAD-cJPY",
+    "id": "PUSO-cZAR",
     "assets": [
       {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
       },
       {
-        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
-        "symbol": "cJPY"
+        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+        "symbol": "cZAR"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
         ]
       }
     ],
@@ -3770,43 +3510,43 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
           "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "cCAD-cCHF",
+    "id": "cCOP-cZAR",
     "assets": [
       {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
       },
       {
-        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
-        "symbol": "cCHF"
+        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+        "symbol": "cZAR"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
         ]
       }
     ],
@@ -3814,11 +3554,55 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
           "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cREAL-cZAR",
+    "assets": [
+      {
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
+      },
+      {
+        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
@@ -3869,296 +3653,516 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "BridgedUSDC-CELO",
+    "id": "PUSO-cJPY",
     "assets": [
       {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
       },
       {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
+        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
+        "symbol": "cJPY"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
         "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
         "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.74875,
+      "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-          "spreadPercent": 0.25
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
-          "spreadPercent": 0.5
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "BridgedUSDC-CELO",
+    "id": "cCOP-cJPY",
     "assets": [
       {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
       },
       {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
+        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
+        "symbol": "cJPY"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
         "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
         "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.74875,
+      "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-          "spreadPercent": 0.25
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
-          "spreadPercent": 0.5
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "BridgedEUROC-CELO",
+    "id": "cJPY-cREAL",
     "assets": [
       {
-        "address": "0x6e673502c5b55F3169657C004e5797fFE5be6653",
-        "symbol": "BridgedEUROC"
+        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
+        "symbol": "cJPY"
       },
-      {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-        "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
-        "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x6e673502c5b55F3169657C004e5797fFE5be6653"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.74875,
-      "hops": [
-        {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
-          "spreadPercent": 0.5
-        }
-      ]
-    }
-  },
-  {
-    "id": "cREAL-cUSD",
-    "assets": [
       {
         "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
         "symbol": "cREAL"
-      },
-      {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
-        "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.74875,
+      "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
-          "spreadPercent": 0.5
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "BridgedUSDC-USDC",
+    "id": "PUSO-cCHF",
     "assets": [
       {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
       },
       {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
+        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
+        "symbol": "cCHF"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
         "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
         "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.74875,
+      "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-          "spreadPercent": 0.25
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
-          "spreadPercent": 0.5
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "BridgedUSDC-USDC",
+    "id": "cCHF-cCOP",
     "assets": [
       {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
+        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
+        "symbol": "cCHF"
       },
       {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
         "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
         "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.74875,
+      "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-          "spreadPercent": 0.25
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
-          "spreadPercent": 0.5
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "BridgedEUROC-USDC",
+    "id": "cCHF-cREAL",
     "assets": [
       {
-        "address": "0x6e673502c5b55F3169657C004e5797fFE5be6653",
-        "symbol": "BridgedEUROC"
+        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
+        "symbol": "cCHF"
       },
       {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
         "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x6e673502c5b55F3169657C004e5797fFE5be6653"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "PUSO-cCOP",
+    "assets": [
+      {
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "PUSO-cREAL",
+    "assets": [
+      {
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCOP-cREAL",
+    "assets": [
+      {
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cAUD-cEUR",
+    "assets": [
+      {
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
+      },
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.64925,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cEUR",
+    "assets": [
+      {
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.64925,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cEUR",
+    "assets": [
+      {
+        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
         ]
       }
     ],
@@ -4166,56 +4170,276 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       "totalSpreadPercent": 0.74875,
       "hops": [
         {
-          "exchangeId": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-          "spreadPercent": 0.25
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
         },
         {
-          "exchangeId": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
-          "spreadPercent": 0.5
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
         }
       ]
     }
   },
   {
-    "id": "cEUR-cUSD",
+    "id": "cEUR-cGBP",
     "assets": [
       {
         "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
         "symbol": "cEUR"
       },
       {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
+        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+        "symbol": "cGBP"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.74875,
+      "totalSpreadPercent": 0.7985,
       "hops": [
         {
-          "exchangeId": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        }
+      ]
+    }
+  },
+  {
+    "id": "cEUR-cZAR",
+    "assets": [
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      },
+      {
+        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.7985,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        }
+      ]
+    }
+  },
+  {
+    "id": "cEUR-cJPY",
+    "assets": [
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      },
+      {
+        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
+        "symbol": "cJPY"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.7985,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
           "spreadPercent": 0.5
         },
         {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCHF-cEUR",
+    "assets": [
+      {
+        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
+        "symbol": "cCHF"
+      },
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.7985,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "PUSO-cEUR",
+    "assets": [
+      {
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.7985,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCOP-cEUR",
+    "assets": [
+      {
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.7985,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
         }
       ]
     }
@@ -4235,54 +4459,54 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.9975,
+      "totalSpreadPercent": 0.7985,
       "hops": [
         {
-          "exchangeId": "0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c",
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
           "spreadPercent": 0.5
         },
         {
-          "exchangeId": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
-          "spreadPercent": 0.5
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "BridgedEUROC-BridgedUSDC",
+    "id": "BridgedEUROC-cUSD",
     "assets": [
       {
         "address": "0x6e673502c5b55F3169657C004e5797fFE5be6653",
         "symbol": "BridgedEUROC"
       },
       {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
+        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+        "symbol": "cUSD"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
         ]
       },
       {
@@ -4298,44 +4522,12 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       "totalSpreadPercent": 0.9975,
       "hops": [
         {
-          "exchangeId": "0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6",
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
           "spreadPercent": 0.5
         },
         {
           "exchangeId": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
           "spreadPercent": 0.5
-        }
-      ]
-    }
-  },
-  {
-    "id": "cKES-cUSD",
-    "assets": [
-      {
-        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
-        "symbol": "cKES"
-      },
-      {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1,
-      "hops": [
-        {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
         }
       ]
     }
@@ -4405,26 +4597,18 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "USDC-cKES",
+    "id": "cKES-cUSD",
     "assets": [
-      {
-        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
-        "symbol": "USDC"
-      },
       {
         "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
         "symbol": "cKES"
+      },
+      {
+        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+        "symbol": "cUSD"
       }
     ],
     "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
-        ]
-      },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
@@ -4435,12 +4619,8 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.0495,
+      "totalSpreadPercent": 1,
       "hops": [
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        },
         {
           "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
           "spreadPercent": 1
@@ -4463,12 +4643,48 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
         ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-cGHS",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
       },
+      {
+        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
@@ -4476,18 +4692,70 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
         ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.0495,
+      "totalSpreadPercent": 1,
       "hops": [
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        },
         {
           "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
           "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDT-cGHS",
+    "assets": [
+      {
+        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+        "symbol": "USDT"
+      },
+      {
+        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "spreadPercent": 0
         }
       ]
     }
@@ -4507,12 +4775,48 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
         ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-cNGN",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
       },
+      {
+        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
@@ -4520,18 +4824,158 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
         ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.0495,
+      "totalSpreadPercent": 1,
       "hops": [
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        },
         {
           "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
           "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDT-cNGN",
+    "assets": [
+      {
+        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+        "symbol": "USDT"
+      },
+      {
+        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cKES",
+    "assets": [
+      {
+        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1,
+      "hops": [
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-cKES",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
+      },
+      {
+        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1,
+      "hops": [
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
         }
       ]
     }
@@ -4567,7 +5011,7 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.0495,
+      "totalSpreadPercent": 1,
       "hops": [
         {
           "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
@@ -4575,17 +5019,17 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
         },
         {
           "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         }
       ]
     }
   },
   {
-    "id": "USDT-cGHS",
+    "id": "cAUD-cGHS",
     "assets": [
       {
-        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
-        "symbol": "USDT"
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
       },
       {
         "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
@@ -4595,129 +5039,41 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
         ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.0495,
+      "totalSpreadPercent": 1.1485,
       "hops": [
-        {
-          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
-        },
         {
           "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
           "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "USDT-cNGN",
-    "assets": [
-      {
-        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
-        "symbol": "USDT"
-      },
-      {
-        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
-        "symbol": "cNGN"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.0495,
-      "hops": [
-        {
-          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
-          "spreadPercent": 0.05
         },
         {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-          "spreadPercent": 1
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
         }
       ]
     }
   },
   {
-    "id": "CELO-cKES",
+    "id": "cCAD-cGHS",
     "assets": [
       {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
-        "symbol": "cKES"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.2475,
-      "hops": [
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "CELO-cGHS",
-    "assets": [
-      {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
       },
       {
         "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
@@ -4727,41 +5083,41 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
         ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.2475,
+      "totalSpreadPercent": 1.1485,
       "hops": [
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        },
         {
           "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
           "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
         }
       ]
     }
   },
   {
-    "id": "CELO-cNGN",
+    "id": "cAUD-cNGN",
     "assets": [
       {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
       },
       {
         "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
@@ -4771,129 +5127,41 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
         ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.2475,
+      "totalSpreadPercent": 1.1485,
       "hops": [
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        },
         {
           "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
           "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-cKES",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
-        "symbol": "cKES"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.2475,
-      "hops": [
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
         },
         {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
         }
       ]
     }
   },
   {
-    "id": "BridgedUSDC-cGHS",
+    "id": "cCAD-cNGN",
     "assets": [
       {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
-      },
-      {
-        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
-        "symbol": "cGHS"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.2475,
-      "hops": [
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "BridgedUSDC-cNGN",
-    "assets": [
-      {
-        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
-        "symbol": "BridgedUSDC"
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
       },
       {
         "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
@@ -4903,75 +5171,31 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x87D61dA3d668797786D73BC674F053f87111570d"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
         ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.2475,
+      "totalSpreadPercent": 1.1485,
       "hops": [
-        {
-          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
-          "spreadPercent": 0.25
-        },
         {
           "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
           "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cKES",
-    "assets": [
-      {
-        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
-        "symbol": "cKES"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
         },
         {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
         }
       ]
     }
@@ -5007,7 +5231,7 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.297,
+      "totalSpreadPercent": 1.1485,
       "hops": [
         {
           "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
@@ -5015,139 +5239,7 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
         },
         {
           "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCOP-cKES",
-    "assets": [
-      {
-        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
-        "symbol": "cCOP"
-      },
-      {
-        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
-        "symbol": "cKES"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cGBP-cKES",
-    "assets": [
-      {
-        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
-        "symbol": "cGBP"
-      },
-      {
-        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
-        "symbol": "cKES"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cKES-cZAR",
-    "assets": [
-      {
-        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
-        "symbol": "cKES"
-      },
-      {
-        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
+          "spreadPercent": 0.15
         }
       ]
     }
@@ -5183,7 +5275,7 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.297,
+      "totalSpreadPercent": 1.1485,
       "hops": [
         {
           "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
@@ -5191,17 +5283,105 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
         },
         {
           "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
+          "spreadPercent": 0.15
         }
       ]
     }
   },
   {
-    "id": "cJPY-cKES",
+    "id": "CELO-cGHS",
     "assets": [
       {
-        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
-        "symbol": "cJPY"
+        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.2475,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cNGN",
+    "assets": [
+      {
+        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.2475,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cKES",
+    "assets": [
+      {
+        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+        "symbol": "CELO"
       },
       {
         "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
@@ -5219,331 +5399,23 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
+          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.297,
+      "totalSpreadPercent": 1.2475,
       "hops": [
         {
           "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
           "spreadPercent": 1
         },
         {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCHF-cKES",
-    "assets": [
-      {
-        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
-        "symbol": "cCHF"
-      },
-      {
-        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
-        "symbol": "cKES"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cGHS",
-    "assets": [
-      {
-        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
-        "symbol": "cGHS"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cNGN",
-    "assets": [
-      {
-        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
-        "symbol": "cNGN"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cGHS",
-    "assets": [
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
-        "symbol": "cGHS"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cNGN",
-    "assets": [
-      {
-        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
-        "symbol": "cNGN"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCOP-cGHS",
-    "assets": [
-      {
-        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
-        "symbol": "cCOP"
-      },
-      {
-        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
-        "symbol": "cGHS"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCOP-cNGN",
-    "assets": [
-      {
-        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
-        "symbol": "cCOP"
-      },
-      {
-        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
-        "symbol": "cNGN"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-          "spreadPercent": 1
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
         }
       ]
     }
@@ -5631,50 +5503,6 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
         },
         {
           "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCAD-cGHS",
-    "assets": [
-      {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
-      },
-      {
-        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
-        "symbol": "cGHS"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
           "spreadPercent": 0.3
         }
       ]
@@ -5769,6 +5597,138 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
+    "id": "PUSO-cGHS",
+    "assets": [
+      {
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCOP-cGHS",
+    "assets": [
+      {
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cGHS-cREAL",
+    "assets": [
+      {
+        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+        "symbol": "cGHS"
+      },
+      {
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
     "id": "cGBP-cNGN",
     "assets": [
       {
@@ -5807,6 +5767,50 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
         },
         {
           "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "cGBP-cKES",
+    "assets": [
+      {
+        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+        "symbol": "cGBP"
+      },
+      {
+        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
           "spreadPercent": 1
         }
       ]
@@ -5857,32 +5861,32 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "cCAD-cNGN",
+    "id": "cKES-cZAR",
     "assets": [
       {
-        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
-        "symbol": "cCAD"
+        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+        "symbol": "cKES"
       },
       {
-        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
-        "symbol": "cNGN"
+        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+        "symbol": "cZAR"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
+          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
         ]
       }
     ],
@@ -5890,11 +5894,11 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       "totalSpreadPercent": 1.297,
       "hops": [
         {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
           "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
           "spreadPercent": 1
         }
       ]
@@ -5915,18 +5919,18 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
         ]
       }
     ],
@@ -5934,12 +5938,12 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       "totalSpreadPercent": 1.297,
       "hops": [
         {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        },
-        {
           "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
           "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
         }
       ]
     }
@@ -5959,6 +5963,226 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "PUSO-cNGN",
+    "assets": [
+      {
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCOP-cNGN",
+    "assets": [
+      {
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cNGN-cREAL",
+    "assets": [
+      {
+        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
+        "symbol": "cNGN"
+      },
+      {
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cJPY-cKES",
+    "assets": [
+      {
+        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
+        "symbol": "cJPY"
+      },
+      {
+        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCHF-cKES",
+    "assets": [
+      {
+        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
+        "symbol": "cCHF"
+      },
+      {
+        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
@@ -5967,10 +6191,10 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
+          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
         ]
       }
     ],
@@ -5982,18 +6206,18 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
           "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
           "spreadPercent": 1
         }
       ]
     }
   },
   {
-    "id": "cGHS-cKES",
+    "id": "PUSO-cKES",
     "assets": [
       {
-        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
-        "symbol": "cGHS"
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
       },
       {
         "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
@@ -6011,33 +6235,165 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.99,
+      "totalSpreadPercent": 1.297,
       "hops": [
         {
           "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
           "spreadPercent": 1
         },
         {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "cKES-cNGN",
+    "id": "cCOP-cKES",
+    "assets": [
+      {
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cKES-cREAL",
     "assets": [
       {
         "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
         "symbol": "cKES"
+      },
+      {
+        "address": "0xE4D517785D091D3c54818832dB6094bcc2744545",
+        "symbol": "cREAL"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cEUR-cGHS",
+    "assets": [
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      },
+      {
+        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.495,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        }
+      ]
+    }
+  },
+  {
+    "id": "cEUR-cNGN",
+    "assets": [
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
       },
       {
         "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
@@ -6047,30 +6403,74 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-        "assets": [
-          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
         "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
         ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.99,
+      "totalSpreadPercent": 1.495,
       "hops": [
         {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
           "spreadPercent": 1
         },
         {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        }
+      ]
+    }
+  },
+  {
+    "id": "cEUR-cKES",
+    "assets": [
+      {
+        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
+        "symbol": "cEUR"
+      },
+      {
+        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.495,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
           "spreadPercent": 1
         }
       ]
@@ -6121,6 +6521,346 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     }
   },
   {
+    "id": "cGHS-cKES",
+    "assets": [
+      {
+        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+        "symbol": "cGHS"
+      },
+      {
+        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.99,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "cKES-cNGN",
+    "assets": [
+      {
+        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+        "symbol": "cKES"
+      },
+      {
+        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.99,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "cUSD-eXOF",
+    "assets": [
+      {
+        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+        "symbol": "cUSD"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2,
+      "hops": [
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-eXOF",
+    "assets": [
+      {
+        "address": "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2,
+      "hops": [
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "BridgedUSDC-eXOF",
+    "assets": [
+      {
+        "address": "0x87D61dA3d668797786D73BC674F053f87111570d",
+        "symbol": "BridgedUSDC"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x87D61dA3d668797786D73BC674F053f87111570d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2,
+      "hops": [
+        {
+          "exchangeId": "0xf77561650ba043a244ae9c58f778c141532c4afdb7cae5e6fd623b565c5584a0",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDT-eXOF",
+    "assets": [
+      {
+        "address": "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287",
+        "symbol": "USDT"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xBba91F588d031469ABCCA566FE80fB1Ad8Ee3287"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2,
+      "hops": [
+        {
+          "exchangeId": "0x36e12d20b7a59b463a1a113caf338cbad9d64ee017548d00a791681f2fbf0763",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cAUD-eXOF",
+    "assets": [
+      {
+        "address": "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0",
+        "symbol": "cAUD"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x84CBD49F5aE07632B6B88094E81Cce8236125Fe0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.147,
+      "hops": [
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-eXOF",
+    "assets": [
+      {
+        "address": "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x02EC9E0D2Fd73e89168C1709e542a48f58d7B133"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.147,
+      "hops": [
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
     "id": "CELO-eXOF",
     "assets": [
       {
@@ -6135,29 +6875,41 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
         "assets": [
-          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
           "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 2,
+      "totalSpreadPercent": 2.245,
       "hops": [
         {
-          "exchangeId": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
           "spreadPercent": 2
         }
       ]
     }
   },
   {
-    "id": "BridgedEUROC-eXOF",
+    "id": "cGBP-eXOF",
     "assets": [
       {
-        "address": "0x6e673502c5b55F3169657C004e5797fFE5be6653",
-        "symbol": "BridgedEUROC"
+        "address": "0x47f2Fb88105155a18c390641C8a73f1402B2BB12",
+        "symbol": "cGBP"
       },
       {
         "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
@@ -6167,18 +6919,250 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
-          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
-          "0x6e673502c5b55F3169657C004e5797fFE5be6653"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x47f2Fb88105155a18c390641C8a73f1402B2BB12"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 2,
+      "totalSpreadPercent": 2.294,
       "hops": [
         {
-          "exchangeId": "0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe",
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cZAR-eXOF",
+    "assets": [
+      {
+        "address": "0x1e5b44015Ff90610b54000DAad31C89b3284df4d",
+        "symbol": "cZAR"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1e5b44015Ff90610b54000DAad31C89b3284df4d"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.294,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cJPY-eXOF",
+    "assets": [
+      {
+        "address": "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67",
+        "symbol": "cJPY"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x2E51F41238cA36a421C9B8b3e189e8Cc7653FE67"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.294,
+      "hops": [
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCHF-eXOF",
+    "assets": [
+      {
+        "address": "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F",
+        "symbol": "cCHF"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xADC57C2C34aD021Df4421230a6532F4e2E1dCE4F"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.294,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "PUSO-eXOF",
+    "assets": [
+      {
+        "address": "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x5E0E3c9419C42a1B04e2525991FB1A2C467AB8bF"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.294,
+      "hops": [
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCOP-eXOF",
+    "assets": [
+      {
+        "address": "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xe6A57340f0df6E020c1c0a80bC6E13048601f0d4"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.294,
+      "hops": [
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
           "spreadPercent": 2
         }
       ]
@@ -6199,119 +7183,31 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-        "assets": [
-          "0xE4D517785D091D3c54818832dB6094bcc2744545",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-        "assets": [
-          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 2.245,
-      "hops": [
-        {
-          "exchangeId": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-          "spreadPercent": 2
-        }
-      ]
-    }
-  },
-  {
-    "id": "cEUR-eXOF",
-    "assets": [
-      {
-        "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-        "symbol": "cEUR"
-      },
-      {
-        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
-        "symbol": "eXOF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-        "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-        "assets": [
-          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 2.245,
-      "hops": [
-        {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-          "spreadPercent": 2
-        }
-      ]
-    }
-  },
-  {
-    "id": "cUSD-eXOF",
-    "assets": [
-      {
-        "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD"
-      },
-      {
-        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
-        "symbol": "eXOF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-        "assets": [
-          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
-        ]
-      },
-      {
-        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          "0xE4D517785D091D3c54818832dB6094bcc2744545"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 2.245,
+      "totalSpreadPercent": 2.294,
       "hops": [
         {
-          "exchangeId": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-          "spreadPercent": 2
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
         }
       ]
     }
@@ -6331,18 +7227,18 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
-          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-          "0x6e673502c5b55F3169657C004e5797fFE5be6653"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
         "assets": [
-          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
-          "0x6e673502c5b55F3169657C004e5797fFE5be6653"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
         ]
       }
     ],
@@ -6350,55 +7246,143 @@ export const tradablePairs44787: TradablePairWithSpread[] = [
       "totalSpreadPercent": 2.49,
       "hops": [
         {
-          "exchangeId": "0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37",
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
           "spreadPercent": 0.5
         },
         {
-          "exchangeId": "0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe",
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
           "spreadPercent": 2
         }
       ]
     }
   },
   {
-    "id": "BridgedEUROC-CELO",
+    "id": "cGHS-eXOF",
     "assets": [
       {
-        "address": "0x6e673502c5b55F3169657C004e5797fFE5be6653",
-        "symbol": "BridgedEUROC"
+        "address": "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375",
+        "symbol": "cGHS"
       },
       {
-        "address": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
-        "symbol": "CELO"
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
       }
     ],
     "path": [
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
         "assets": [
-          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
-          "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x295B66bE7714458Af45E6A6Ea142A5358A6cA375"
         ]
       },
       {
         "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
-        "id": "0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
         "assets": [
-          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
-          "0x6e673502c5b55F3169657C004e5797fFE5be6653"
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 3.96,
+      "totalSpreadPercent": 2.98,
       "hops": [
         {
-          "exchangeId": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-          "spreadPercent": 2
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
         },
         {
-          "exchangeId": "0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe",
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cNGN-eXOF",
+    "assets": [
+      {
+        "address": "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0",
+        "symbol": "cNGN"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x4a5b03B8b16122D330306c65e4CA4BC5Dd6511d0"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.98,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cKES-eXOF",
+    "assets": [
+      {
+        "address": "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92",
+        "symbol": "cKES"
+      },
+      {
+        "address": "0xB0FA15e002516d0301884059c0aaC0F0C72b019D",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0x1E0433C1769271ECcF4CFF9FDdD515eefE6CdF92"
+        ]
+      },
+      {
+        "providerAddr": "0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
+          "0xB0FA15e002516d0301884059c0aaC0F0C72b019D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.98,
+      "hops": [
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
           "spreadPercent": 2
         }
       ]


### PR DESCRIPTION
### Description

This adds the new pairs after executing the pool restructuring on Alfajores and running the `cacheTradablePairs` script. 

### Other changes

N/A

### Tested

Will deploy this on mento-web after this is merged
