### PR TITLE
feat: new trading pairs on mainnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/src/constants/tradablePairs.42220.ts
+++ b/src/constants/tradablePairs.42220.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on 2025-06-24T11:09:14.613Z
+// Generated on 2025-07-11T11:11:56.576Z
 
 import { TradablePairWithSpread } from './tradablePairs'
 
@@ -27,11 +27,43 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.05,
+      "totalSpreadPercent": 0,
       "hops": [
         {
           "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "axlUSDC-cUSD",
+    "assets": [
+      {
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
+      },
+      {
+        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+        "symbol": "cUSD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0,
+      "hops": [
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
         }
       ]
     }
@@ -59,11 +91,55 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.05,
+      "totalSpreadPercent": 0,
       "hops": [
         {
           "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-axlUSDC",
+    "assets": [
+      {
+        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0,
+      "hops": [
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
         }
       ]
     }
@@ -99,157 +175,29 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.099975,
+      "totalSpreadPercent": 0,
       "hops": [
         {
           "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
           "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         }
       ]
     }
   },
   {
-    "id": "CELO-cEUR",
+    "id": "USD₮-axlUSDC",
     "assets": [
       {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
+        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+        "symbol": "USD₮"
       },
-      {
-        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-        "symbol": "cEUR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-        "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.25,
-      "hops": [
-        {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "CELO-cREAL",
-    "assets": [
-      {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-        "symbol": "cREAL"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-        "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.25,
-      "hops": [
-        {
-          "exchangeId": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "USDC-cREAL",
-    "assets": [
-      {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
-      },
-      {
-        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-        "symbol": "cREAL"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-        "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.25,
-      "hops": [
-        {
-          "exchangeId": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "USDC-cEUR",
-    "assets": [
-      {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
-      },
-      {
-        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-        "symbol": "cEUR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-        "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.25,
-      "hops": [
-        {
-          "exchangeId": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "axlUSDC-cUSD",
-    "assets": [
       {
         "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
         "symbol": "axlUSDC"
-      },
-      {
-        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-        "symbol": "cUSD"
       }
     ],
     "path": [
@@ -260,14 +208,354 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
         ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.25,
+      "totalSpreadPercent": 0,
       "hops": [
         {
           "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "cAUD-cUSD",
+    "assets": [
+      {
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
+      },
+      {
+        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+        "symbol": "cUSD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cUSD",
+    "assets": [
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+        "symbol": "cUSD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cAUD",
+    "assets": [
+      {
+        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "axlUSDC-cAUD",
+    "assets": [
+      {
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
+      },
+      {
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USD₮-cAUD",
+    "assets": [
+      {
+        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+        "symbol": "USD₮"
+      },
+      {
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cCAD",
+    "assets": [
+      {
+        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "axlUSDC-cCAD",
+    "assets": [
+      {
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
+      },
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "USD₮-cCAD",
+    "assets": [
+      {
+        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+        "symbol": "USD₮"
+      },
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.15,
+      "hops": [
+        {
+          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
         }
       ]
     }
@@ -335,7 +623,7 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.299875,
+      "totalSpreadPercent": 0.25,
       "hops": [
         {
           "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
@@ -343,7 +631,51 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
         },
         {
           "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-axlUSDC",
+    "assets": [
+      {
+        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.25,
+      "hops": [
+        {
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
+        },
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
         }
       ]
     }
@@ -379,7 +711,7 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.299875,
+      "totalSpreadPercent": 0.25,
       "hops": [
         {
           "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
@@ -387,17 +719,61 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
         },
         {
           "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         }
       ]
     }
   },
   {
-    "id": "cEUR-cUSD",
+    "id": "cAUD-cCAD",
     "assets": [
       {
-        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-        "symbol": "cEUR"
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
+      },
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.299775,
+      "hops": [
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cGBP-cUSD",
+    "assets": [
+      {
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
       },
       {
         "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
@@ -407,41 +783,61 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-        "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.299875,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
-          "exchangeId": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "cREAL-cUSD",
+    "id": "cUSD-cZAR",
     "assets": [
       {
-        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-        "symbol": "cREAL"
+        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+        "symbol": "cUSD"
+      },
+      {
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCHF-cUSD",
+    "assets": [
+      {
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
       },
       {
         "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
@@ -451,119 +847,19 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-        "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.299875,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
-          "exchangeId": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        }
-      ]
-    }
-  },
-  {
-    "id": "USDC-axlUSDC",
-    "assets": [
-      {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
-      },
-      {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.299875,
-      "hops": [
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        },
-        {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "USD₮-axlUSDC",
-    "assets": [
-      {
-        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-        "symbol": "USD₮"
-      },
-      {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.299875,
-      "hops": [
-        {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
         }
       ]
     }
@@ -665,15 +961,47 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "cGBP-cUSD",
+    "id": "cREAL-cUSD",
     "assets": [
       {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
       },
       {
         "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
         "symbol": "cUSD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cGBP",
+    "assets": [
+      {
+        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
       }
     ],
     "path": [
@@ -684,6 +1012,14 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
         ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+        ]
       }
     ],
     "spreadData": {
@@ -692,16 +1028,108 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
         {
           "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
           "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
         }
       ]
     }
   },
   {
-    "id": "cUSD-cZAR",
+    "id": "axlUSDC-cGBP",
     "assets": [
       {
-        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-        "symbol": "cUSD"
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
+      },
+      {
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USD₮-cGBP",
+    "assets": [
+      {
+        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+        "symbol": "USD₮"
+      },
+      {
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cZAR",
+    "assets": [
+      {
+        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+        "symbol": "USDC"
       },
       {
         "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
@@ -716,6 +1144,14 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
         ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+        ]
       }
     ],
     "spreadData": {
@@ -724,29 +1160,41 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
         {
           "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
           "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
         }
       ]
     }
   },
   {
-    "id": "cCAD-cUSD",
+    "id": "axlUSDC-cZAR",
     "assets": [
       {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
       },
       {
-        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-        "symbol": "cUSD"
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
         ]
       }
     ],
@@ -754,31 +1202,43 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       "totalSpreadPercent": 0.3,
       "hops": [
         {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
           "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
         }
       ]
     }
   },
   {
-    "id": "cAUD-cUSD",
+    "id": "USD₮-cZAR",
     "assets": [
       {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
+        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+        "symbol": "USD₮"
       },
       {
-        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-        "symbol": "cUSD"
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
         ]
       }
     ],
@@ -786,22 +1246,26 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       "totalSpreadPercent": 0.3,
       "hops": [
         {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
           "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "spreadPercent": 0
         }
       ]
     }
   },
   {
-    "id": "cCHF-cUSD",
+    "id": "USDC-cCHF",
     "assets": [
+      {
+        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+        "symbol": "USDC"
+      },
       {
         "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
         "symbol": "cCHF"
-      },
-      {
-        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-        "symbol": "cUSD"
       }
     ],
     "path": [
@@ -812,6 +1276,14 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
         ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+        ]
       }
     ],
     "spreadData": {
@@ -820,6 +1292,98 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
         {
           "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
           "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "axlUSDC-cCHF",
+    "assets": [
+      {
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
+      },
+      {
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USD₮-cCHF",
+    "assets": [
+      {
+        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+        "symbol": "USD₮"
+      },
+      {
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.3,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "spreadPercent": 0
         }
       ]
     }
@@ -855,11 +1419,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
           "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
@@ -899,11 +1463,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
           "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
@@ -943,11 +1507,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
           "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
@@ -957,15 +1521,15 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "USDC-cGBP",
+    "id": "USDC-cREAL",
     "assets": [
       {
         "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
         "symbol": "USDC"
       },
       {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
       }
     ],
     "path": [
@@ -979,198 +1543,198 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "USDC-cZAR",
+    "id": "PUSO-axlUSDC",
     "assets": [
       {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
+        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+        "symbol": "PUSO"
       },
       {
-        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-        "symbol": "cZAR"
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
         },
         {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "USDC-cCAD",
+    "id": "axlUSDC-cJPY",
     "assets": [
       {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
       },
       {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
+        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+        "symbol": "cJPY"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
+          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
         },
         {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "USDC-cAUD",
+    "id": "axlUSDC-cCOP",
     "assets": [
       {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
       },
       {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
+        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+        "symbol": "cCOP"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
+          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
         },
         {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "USDC-cCHF",
+    "id": "axlUSDC-cREAL",
     "assets": [
       {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
       },
       {
-        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-        "symbol": "cCHF"
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
         },
         {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
@@ -1207,11 +1771,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
           "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
@@ -1251,11 +1815,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
           "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
@@ -1295,11 +1859,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
           "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
@@ -1309,15 +1873,15 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "USD₮-cGBP",
+    "id": "USD₮-cREAL",
     "assets": [
       {
         "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
         "symbol": "USD₮"
       },
       {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
       }
     ],
     "path": [
@@ -1331,77 +1895,77 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.3,
       "hops": [
         {
           "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         },
         {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "USD₮-cZAR",
+    "id": "CELO-cAUD",
     "assets": [
       {
-        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-        "symbol": "USD₮"
+        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+        "symbol": "CELO"
       },
       {
-        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-        "symbol": "cZAR"
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+          "0x471EcE3750Da237f93B8E339c536989b8978a438"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.399625,
       "hops": [
         {
-          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
         },
         {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
         }
       ]
     }
   },
   {
-    "id": "USD₮-cCAD",
+    "id": "CELO-cCAD",
     "assets": [
       {
-        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-        "symbol": "USD₮"
+        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+        "symbol": "CELO"
       },
       {
         "address": "0xff4Ab19391af240c311c54200a492233052B6325",
@@ -1411,10 +1975,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          "0x471EcE3750Da237f93B8E339c536989b8978a438"
         ]
       },
       {
@@ -1427,38 +1991,38 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.399625,
       "hops": [
         {
-          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
         },
         {
           "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
+          "spreadPercent": 0.15
         }
       ]
     }
   },
   {
-    "id": "USD₮-cAUD",
+    "id": "cAUD-cGBP",
     "assets": [
-      {
-        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-        "symbol": "USD₮"
-      },
       {
         "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
         "symbol": "cAUD"
+      },
+      {
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
         ]
       },
       {
@@ -1471,25 +2035,157 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
         },
         {
           "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
+          "spreadPercent": 0.15
         }
       ]
     }
   },
   {
-    "id": "USD₮-cCHF",
+    "id": "cCAD-cGBP",
     "assets": [
       {
-        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-        "symbol": "USD₮"
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cAUD-cZAR",
+    "assets": [
+      {
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
+      },
+      {
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cZAR",
+    "assets": [
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cAUD-cCHF",
+    "assets": [
+      {
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
       },
       {
         "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
@@ -1499,10 +2195,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
         ]
       },
       {
@@ -1515,11 +2211,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.34985,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
         },
         {
           "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
@@ -1529,143 +2225,143 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "CELO-axlUSDC",
+    "id": "PUSO-cAUD",
     "assets": [
       {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
+        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+        "symbol": "PUSO"
       },
       {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.499375,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
         },
         {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "CELO-USDC",
+    "id": "cAUD-cJPY",
     "assets": [
       {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
       },
       {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
+        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+        "symbol": "cJPY"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
         "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
         "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.499375,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-          "spreadPercent": 0.25
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
         },
         {
-          "exchangeId": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-          "spreadPercent": 0.25
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "CELO-USDC",
+    "id": "cAUD-cCOP",
     "assets": [
       {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
       },
       {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
+        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+        "symbol": "cCOP"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
         "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
         "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.499375,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-          "spreadPercent": 0.25
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
         },
         {
-          "exchangeId": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-          "spreadPercent": 0.25
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "cEUR-cREAL",
+    "id": "cAUD-cREAL",
     "assets": [
       {
-        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-        "symbol": "cEUR"
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
       },
       {
         "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
@@ -1675,205 +2371,217 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-        "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-        "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.499375,
-      "hops": [
-        {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "cEUR-cREAL",
-    "assets": [
-      {
-        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-        "symbol": "cEUR"
-      },
-      {
-        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-        "symbol": "cREAL"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-        "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-        "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.499375,
-      "hops": [
-        {
-          "exchangeId": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "cEUR-cUSD",
-    "assets": [
-      {
-        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-        "symbol": "cEUR"
-      },
-      {
-        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-        "symbol": "cUSD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-        "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.499375,
-      "hops": [
-        {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "cREAL-cUSD",
-    "assets": [
-      {
-        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-        "symbol": "cREAL"
-      },
-      {
-        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-        "symbol": "cUSD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-        "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.499375,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-          "spreadPercent": 0.25
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
         },
         {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "axlUSDC-cEUR",
+    "id": "cCAD-cCHF",
     "assets": [
       {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
       },
       {
-        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-        "symbol": "cEUR"
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
         "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.5,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
-          "spreadPercent": 0.5
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
         }
       ]
     }
   },
   {
-    "id": "axlUSDC-cREAL",
+    "id": "PUSO-cCAD",
     "assets": [
       {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
+        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cJPY",
+    "assets": [
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+        "symbol": "cJPY"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cCOP",
+    "assets": [
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+        "symbol": "cCOP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.44955,
+      "hops": [
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cREAL",
+    "assets": [
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
       },
       {
         "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
@@ -1883,19 +2591,31 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
         "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.5,
+      "totalSpreadPercent": 0.44955,
       "hops": [
         {
-          "exchangeId": "0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df",
-          "spreadPercent": 0.5
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
         }
       ]
     }
@@ -1928,6 +2648,302 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
         {
           "exchangeId": "0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48",
           "spreadPercent": 0.5
+        }
+      ]
+    }
+  },
+  {
+    "id": "cEUR-cUSD",
+    "assets": [
+      {
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
+      },
+      {
+        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+        "symbol": "cUSD"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cEUR",
+    "assets": [
+      {
+        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "axlUSDC-cEUR",
+    "assets": [
+      {
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
+      },
+      {
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USD₮-cEUR",
+    "assets": [
+      {
+        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+        "symbol": "USD₮"
+      },
+      {
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cGBP",
+    "assets": [
+      {
+        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.54925,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cZAR",
+    "assets": [
+      {
+        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.54925,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cCHF",
+    "assets": [
+      {
+        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.54925,
+      "hops": [
+        {
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
+        },
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
         }
       ]
     }
@@ -2065,15 +3081,15 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "CELO-cGBP",
+    "id": "CELO-cREAL",
     "assets": [
       {
         "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
         "symbol": "CELO"
       },
       {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
       }
     ],
     "path": [
@@ -2087,10 +3103,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
         ]
       }
     ],
@@ -2102,18 +3118,18 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "spreadPercent": 0.25
         },
         {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "CELO-cZAR",
+    "id": "cGBP-cZAR",
     "assets": [
       {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
       },
       {
         "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
@@ -2123,10 +3139,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
         ]
       },
       {
@@ -2139,11 +3155,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.54925,
+      "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
         },
         {
           "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
@@ -2153,112 +3169,24 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "CELO-cCAD",
+    "id": "cCHF-cGBP",
     "assets": [
-      {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "CELO-cAUD",
-    "assets": [
-      {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "CELO-cCHF",
-    "assets": [
-      {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
-      },
       {
         "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
         "symbol": "cCHF"
+      },
+      {
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
         ]
       },
       {
@@ -2271,11 +3199,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.54925,
+      "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
         },
         {
           "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
@@ -2285,24 +3213,24 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "PUSO-axlUSDC",
+    "id": "PUSO-cGBP",
     "assets": [
       {
         "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
         "symbol": "PUSO"
       },
       {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
         ]
       },
       {
@@ -2315,11 +3243,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.54925,
+      "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
         },
         {
           "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
@@ -2329,11 +3257,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "axlUSDC-cJPY",
+    "id": "cGBP-cJPY",
     "assets": [
       {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
       },
       {
         "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
@@ -2343,10 +3271,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
         ]
       },
       {
@@ -2359,11 +3287,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.54925,
+      "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
         },
         {
           "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
@@ -2373,24 +3301,24 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "axlUSDC-cCOP",
+    "id": "cCOP-cGBP",
     "assets": [
-      {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
-      },
       {
         "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
         "symbol": "cCOP"
+      },
+      {
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
         ]
       },
       {
@@ -2403,11 +3331,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.54925,
+      "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
         },
         {
           "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
@@ -2417,26 +3345,18 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "axlUSDC-cGBP",
+    "id": "cGBP-cREAL",
     "assets": [
-      {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
-      },
       {
         "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
         "symbol": "cGBP"
+      },
+      {
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
       }
     ],
     "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
-        ]
-      },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
         "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
@@ -2444,28 +3364,36 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
         ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.54925,
+      "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "axlUSDC-cZAR",
+    "id": "cCHF-cZAR",
     "assets": [
       {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
       },
       {
         "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
@@ -2475,142 +3403,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
         "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "axlUSDC-cCAD",
-    "assets": [
-      {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
-      },
-      {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "axlUSDC-cAUD",
-    "assets": [
-      {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
-      },
-      {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.54925,
-      "hops": [
-        {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "axlUSDC-cCHF",
-    "assets": [
-      {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
-      },
-      {
-        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-        "symbol": "cCHF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
         ]
       },
       {
@@ -2623,14 +3419,366 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.54925,
+      "totalSpreadPercent": 0.5991,
       "hops": [
         {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
         },
         {
           "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "PUSO-cZAR",
+    "assets": [
+      {
+        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cJPY-cZAR",
+    "assets": [
+      {
+        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+        "symbol": "cJPY"
+      },
+      {
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCOP-cZAR",
+    "assets": [
+      {
+        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cREAL-cZAR",
+    "assets": [
+      {
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
+      },
+      {
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "PUSO-cCHF",
+    "assets": [
+      {
+        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCHF-cJPY",
+    "assets": [
+      {
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
+      },
+      {
+        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+        "symbol": "cJPY"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCHF-cCOP",
+    "assets": [
+      {
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
+      },
+      {
+        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+        "symbol": "cCOP"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCHF-cREAL",
+    "assets": [
+      {
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
+      },
+      {
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.5991,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
@@ -2725,15 +3873,15 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "PUSO-cGBP",
+    "id": "PUSO-cREAL",
     "assets": [
       {
         "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
         "symbol": "PUSO"
       },
       {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
       }
     ],
     "path": [
@@ -2747,10 +3895,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
         ]
       }
     ],
@@ -2762,183 +3910,7 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cZAR",
-    "assets": [
-      {
-        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cCAD",
-    "assets": [
-      {
-        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cAUD",
-    "assets": [
-      {
-        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cCHF",
-    "assets": [
-      {
-        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-        "symbol": "cCHF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
@@ -2989,15 +3961,15 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "cGBP-cJPY",
+    "id": "cJPY-cREAL",
     "assets": [
-      {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
-      },
       {
         "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
         "symbol": "cJPY"
+      },
+      {
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
       }
     ],
     "path": [
@@ -3011,10 +3983,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
         ]
       }
     ],
@@ -3026,198 +3998,22 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "cJPY-cZAR",
-    "assets": [
-      {
-        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-        "symbol": "cJPY"
-      },
-      {
-        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCAD-cJPY",
-    "assets": [
-      {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
-      },
-      {
-        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-        "symbol": "cJPY"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cJPY",
-    "assets": [
-      {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-        "symbol": "cJPY"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCHF-cJPY",
-    "assets": [
-      {
-        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-        "symbol": "cCHF"
-      },
-      {
-        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-        "symbol": "cJPY"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCOP-cGBP",
+    "id": "cCOP-cREAL",
     "assets": [
       {
         "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
         "symbol": "cCOP"
       },
       {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
       }
     ],
     "path": [
@@ -3231,10 +4027,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
         ]
       }
     ],
@@ -3246,594 +4042,22 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "cCOP-cZAR",
-    "assets": [
-      {
-        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
-        "symbol": "cCOP"
-      },
-      {
-        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCAD-cCOP",
-    "assets": [
-      {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
-      },
-      {
-        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
-        "symbol": "cCOP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cCOP",
+    "id": "cAUD-cEUR",
     "assets": [
       {
         "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
         "symbol": "cAUD"
       },
       {
-        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
-        "symbol": "cCOP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCHF-cCOP",
-    "assets": [
-      {
-        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-        "symbol": "cCHF"
-      },
-      {
-        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
-        "symbol": "cCOP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cGBP-cZAR",
-    "assets": [
-      {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
-      },
-      {
-        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCAD-cGBP",
-    "assets": [
-      {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
-      },
-      {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cGBP",
-    "assets": [
-      {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCHF-cGBP",
-    "assets": [
-      {
-        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-        "symbol": "cCHF"
-      },
-      {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCAD-cZAR",
-    "assets": [
-      {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
-      },
-      {
-        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cZAR",
-    "assets": [
-      {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCHF-cZAR",
-    "assets": [
-      {
-        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-        "symbol": "cCHF"
-      },
-      {
-        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cCAD",
-    "assets": [
-      {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCAD-cCHF",
-    "assets": [
-      {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
-      },
-      {
-        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-        "symbol": "cCHF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.5991,
-      "hops": [
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cCHF",
-    "assets": [
-      {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-        "symbol": "cCHF"
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
       }
     ],
     "path": [
@@ -3847,54 +4071,98 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.5991,
+      "totalSpreadPercent": 0.64925,
       "hops": [
         {
           "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
+          "spreadPercent": 0.15
         },
         {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
         }
       ]
     }
   },
   {
-    "id": "CELO-axlUSDC",
+    "id": "cCAD-cEUR",
+    "assets": [
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.64925,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cEUR",
     "assets": [
       {
         "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
         "symbol": "CELO"
       },
       {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
         "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0x471EcE3750Da237f93B8E339c536989b8978a438"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
         ]
       }
     ],
@@ -3902,320 +4170,276 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       "totalSpreadPercent": 0.74875,
       "hops": [
         {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
           "spreadPercent": 0.25
         },
         {
-          "exchangeId": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
           "spreadPercent": 0.5
         }
       ]
     }
   },
   {
-    "id": "CELO-axlUSDC",
-    "assets": [
-      {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-        "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df",
-        "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.74875,
-      "hops": [
-        {
-          "exchangeId": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df",
-          "spreadPercent": 0.5
-        }
-      ]
-    }
-  },
-  {
-    "id": "CELO-axlEUROC",
-    "assets": [
-      {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
-      },
-      {
-        "address": "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d",
-        "symbol": "axlEUROC"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-        "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48",
-        "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.74875,
-      "hops": [
-        {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48",
-          "spreadPercent": 0.5
-        }
-      ]
-    }
-  },
-  {
-    "id": "cEUR-cUSD",
+    "id": "cEUR-cGBP",
     "assets": [
       {
         "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
         "symbol": "cEUR"
       },
       {
-        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-        "symbol": "cUSD"
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
-        "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.74875,
-      "hops": [
-        {
-          "exchangeId": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
-          "spreadPercent": 0.5
-        },
-        {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "cREAL-cUSD",
-    "assets": [
-      {
-        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-        "symbol": "cREAL"
-      },
-      {
-        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-        "symbol": "cUSD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df",
-        "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.74875,
+      "totalSpreadPercent": 0.7985,
       "hops": [
         {
-          "exchangeId": "0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df",
-          "spreadPercent": 0.5
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
-        }
-      ]
-    }
-  },
-  {
-    "id": "USDC-axlUSDC",
-    "assets": [
-      {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
-      },
-      {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-        "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df",
-        "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 0.74875,
-      "hops": [
-        {
-          "exchangeId": "0xe8693b17c0f002f6a2fe839525557cef10dfeacef9e16c9bbdcb01c57933ce58",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df",
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
           "spreadPercent": 0.5
         }
       ]
     }
   },
   {
-    "id": "USDC-axlUSDC",
+    "id": "cEUR-cZAR",
     "assets": [
       {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
       },
       {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
         "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.74875,
+      "totalSpreadPercent": 0.7985,
       "hops": [
         {
-          "exchangeId": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-          "spreadPercent": 0.25
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
           "spreadPercent": 0.5
         }
       ]
     }
   },
   {
-    "id": "USDC-axlEUROC",
+    "id": "cCHF-cEUR",
     "assets": [
       {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
       },
       {
-        "address": "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d",
-        "symbol": "axlEUROC"
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
         "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.74875,
+      "totalSpreadPercent": 0.7985,
       "hops": [
         {
-          "exchangeId": "0x99be8b8341ba00914600cda701568ab27eea9aca7a32fa48c26e07b86841020c",
-          "spreadPercent": 0.25
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
         },
         {
-          "exchangeId": "0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48",
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "PUSO-cEUR",
+    "assets": [
+      {
+        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.7985,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
           "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cEUR-cJPY",
+    "assets": [
+      {
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
+      },
+      {
+        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+        "symbol": "cJPY"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.7985,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCOP-cEUR",
+    "assets": [
+      {
+        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 0.7985,
+      "hops": [
+        {
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
         }
       ]
     }
@@ -4235,54 +4459,54 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 0.9975,
+      "totalSpreadPercent": 0.7985,
       "hops": [
         {
-          "exchangeId": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
           "spreadPercent": 0.5
         },
         {
-          "exchangeId": "0x40c8472edd23f2976b0503db2692e8f06f0eb52db690e84697cad36a6b44e2df",
-          "spreadPercent": 0.5
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "axlEUROC-axlUSDC",
+    "id": "axlEUROC-cUSD",
     "assets": [
       {
         "address": "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d",
         "symbol": "axlEUROC"
       },
       {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
+        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+        "symbol": "cUSD"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
         ]
       },
       {
@@ -4298,44 +4522,12 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       "totalSpreadPercent": 0.9975,
       "hops": [
         {
-          "exchangeId": "0xf418803158d881fda22694067bf6479476cec22ecfeeca2f6a65a6259bdbb9c0",
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
           "spreadPercent": 0.5
         },
         {
           "exchangeId": "0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48",
           "spreadPercent": 0.5
-        }
-      ]
-    }
-  },
-  {
-    "id": "cKES-cUSD",
-    "assets": [
-      {
-        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
-        "symbol": "cKES"
-      },
-      {
-        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-        "symbol": "cUSD"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1,
-      "hops": [
-        {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
         }
       ]
     }
@@ -4405,26 +4597,18 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "USDC-cKES",
+    "id": "cKES-cUSD",
     "assets": [
-      {
-        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-        "symbol": "USDC"
-      },
       {
         "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
         "symbol": "cKES"
+      },
+      {
+        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+        "symbol": "cUSD"
       }
     ],
     "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
-        ]
-      },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
         "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
@@ -4435,12 +4619,8 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.0495,
+      "totalSpreadPercent": 1,
       "hops": [
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        },
         {
           "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
           "spreadPercent": 1
@@ -4463,12 +4643,48 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
         "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
         ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "axlUSDC-cGHS",
+    "assets": [
+      {
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
       },
+      {
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
         "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
@@ -4476,18 +4692,70 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
         ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.0495,
+      "totalSpreadPercent": 1,
       "hops": [
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        },
         {
           "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
           "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USD₮-cGHS",
+    "assets": [
+      {
+        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+        "symbol": "USD₮"
+      },
+      {
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "spreadPercent": 0
         }
       ]
     }
@@ -4507,12 +4775,48 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
         "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
         ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "axlUSDC-cNGN",
+    "assets": [
+      {
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
       },
+      {
+        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
         "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
@@ -4520,18 +4824,158 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
         ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.0495,
+      "totalSpreadPercent": 1,
       "hops": [
-        {
-          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
-          "spreadPercent": 0.05
-        },
         {
           "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
           "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USD₮-cNGN",
+    "assets": [
+      {
+        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+        "symbol": "USD₮"
+      },
+      {
+        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-cKES",
+    "assets": [
+      {
+        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1,
+      "hops": [
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        }
+      ]
+    }
+  },
+  {
+    "id": "axlUSDC-cKES",
+    "assets": [
+      {
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
+      },
+      {
+        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1,
+      "hops": [
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
         }
       ]
     }
@@ -4567,7 +5011,7 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.0495,
+      "totalSpreadPercent": 1,
       "hops": [
         {
           "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
@@ -4575,17 +5019,17 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
         },
         {
           "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "spreadPercent": 0
         }
       ]
     }
   },
   {
-    "id": "USD₮-cGHS",
+    "id": "cAUD-cGHS",
     "assets": [
       {
-        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-        "symbol": "USD₮"
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
       },
       {
         "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
@@ -4595,12 +5039,48 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
         ]
       },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.1485,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cGHS",
+    "assets": [
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
         "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
@@ -4608,28 +5088,36 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
         ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.0495,
+      "totalSpreadPercent": 1.1485,
       "hops": [
-        {
-          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
-        },
         {
           "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
           "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
         }
       ]
     }
   },
   {
-    "id": "USD₮-cNGN",
+    "id": "cAUD-cNGN",
     "assets": [
       {
-        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-        "symbol": "USD₮"
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
       },
       {
         "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
@@ -4639,10 +5127,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
         ]
       },
       {
@@ -4655,11 +5143,231 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.0495,
+      "totalSpreadPercent": 1.1485,
       "hops": [
         {
-          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
-          "spreadPercent": 0.05
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "cAUD-cKES",
+    "assets": [
+      {
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
+      },
+      {
+        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.1485,
+      "hops": [
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cNGN",
+    "assets": [
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.1485,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-cKES",
+    "assets": [
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.1485,
+      "hops": [
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cGHS",
+    "assets": [
+      {
+        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.2475,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
+        }
+      ]
+    }
+  },
+  {
+    "id": "CELO-cNGN",
+    "assets": [
+      {
+        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+        "symbol": "CELO"
+      },
+      {
+        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.2475,
+      "hops": [
+        {
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+          "spreadPercent": 0.25
         },
         {
           "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
@@ -4713,11 +5421,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "CELO-cGHS",
+    "id": "cGBP-cGHS",
     "assets": [
       {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
       },
       {
         "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
@@ -4727,12 +5435,48 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
         ]
       },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cGHS-cZAR",
+    "assets": [
+      {
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
+      },
+      {
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
         "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
@@ -4740,28 +5484,256 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
         ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.2475,
+      "totalSpreadPercent": 1.297,
       "hops": [
-        {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
-        },
         {
           "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
           "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "CELO-cNGN",
+    "id": "cCHF-cGHS",
     "assets": [
       {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
+      },
+      {
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "PUSO-cGHS",
+    "assets": [
+      {
+        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cGHS-cJPY",
+    "assets": [
+      {
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
+      },
+      {
+        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+        "symbol": "cJPY"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCOP-cGHS",
+    "assets": [
+      {
+        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cGHS-cREAL",
+    "assets": [
+      {
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
+      },
+      {
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cGBP-cNGN",
+    "assets": [
+      {
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
       },
       {
         "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
@@ -4771,10 +5743,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
         ]
       },
       {
@@ -4787,11 +5759,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.2475,
+      "totalSpreadPercent": 1.297,
       "hops": [
         {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
         },
         {
           "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
@@ -4801,11 +5773,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "axlUSDC-cKES",
+    "id": "cGBP-cKES",
     "assets": [
       {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
       },
       {
         "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
@@ -4815,10 +5787,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
         ]
       },
       {
@@ -4831,11 +5803,11 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.2475,
+      "totalSpreadPercent": 1.297,
       "hops": [
         {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
         },
         {
           "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
@@ -4845,68 +5817,24 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "axlUSDC-cGHS",
+    "id": "cNGN-cZAR",
     "assets": [
-      {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
-      },
-      {
-        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-        "symbol": "cGHS"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.2475,
-      "hops": [
-        {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "axlUSDC-cNGN",
-    "assets": [
-      {
-        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-        "symbol": "axlUSDC"
-      },
       {
         "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
         "symbol": "cNGN"
+      },
+      {
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
         ]
       },
       {
@@ -4919,15 +5847,323 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.2475,
+      "totalSpreadPercent": 1.297,
       "hops": [
         {
-          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
-          "spreadPercent": 0.25
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
         },
         {
           "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
           "spreadPercent": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "cKES-cZAR",
+    "assets": [
+      {
+        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+        "symbol": "cKES"
+      },
+      {
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCHF-cNGN",
+    "assets": [
+      {
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
+      },
+      {
+        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCHF-cKES",
+    "assets": [
+      {
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
+      },
+      {
+        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "PUSO-cNGN",
+    "assets": [
+      {
+        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cJPY-cNGN",
+    "assets": [
+      {
+        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+        "symbol": "cJPY"
+      },
+      {
+        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCOP-cNGN",
+    "assets": [
+      {
+        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        }
+      ]
+    }
+  },
+  {
+    "id": "cNGN-cREAL",
+    "assets": [
+      {
+        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+        "symbol": "cNGN"
+      },
+      {
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.297,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
         }
       ]
     }
@@ -5065,15 +6301,15 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
-    "id": "cGBP-cKES",
+    "id": "cKES-cREAL",
     "assets": [
-      {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
-      },
       {
         "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
         "symbol": "cKES"
+      },
+      {
+        "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+        "symbol": "cREAL"
       }
     ],
     "path": [
@@ -5087,10 +6323,10 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
         ]
       }
     ],
@@ -5102,150 +6338,106 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "spreadPercent": 1
         },
         {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
           "spreadPercent": 0.3
         }
       ]
     }
   },
   {
-    "id": "cKES-cZAR",
+    "id": "cEUR-cGHS",
     "assets": [
       {
-        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
-        "symbol": "cKES"
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
       },
       {
-        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-        "symbol": "cZAR"
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.297,
+      "totalSpreadPercent": 1.495,
       "hops": [
         {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
           "spreadPercent": 1
         },
         {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
         }
       ]
     }
   },
   {
-    "id": "cCAD-cKES",
+    "id": "cEUR-cNGN",
     "assets": [
       {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
       },
       {
-        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
-        "symbol": "cKES"
+        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+        "symbol": "cNGN"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
+          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.297,
+      "totalSpreadPercent": 1.495,
       "hops": [
         {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
         },
         {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
         }
       ]
     }
   },
   {
-    "id": "cAUD-cKES",
+    "id": "cEUR-cKES",
     "assets": [
       {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
-        "symbol": "cKES"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCHF-cKES",
-    "assets": [
-      {
-        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-        "symbol": "cCHF"
+        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+        "symbol": "cEUR"
       },
       {
         "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
@@ -5255,752 +6447,12 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
         ]
       },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cGHS",
-    "assets": [
-      {
-        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-        "symbol": "cGHS"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "PUSO-cNGN",
-    "assets": [
-      {
-        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
-        "symbol": "PUSO"
-      },
-      {
-        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-        "symbol": "cNGN"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cGHS-cJPY",
-    "assets": [
-      {
-        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-        "symbol": "cGHS"
-      },
-      {
-        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-        "symbol": "cJPY"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cJPY-cNGN",
-    "assets": [
-      {
-        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-        "symbol": "cJPY"
-      },
-      {
-        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-        "symbol": "cNGN"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCOP-cGHS",
-    "assets": [
-      {
-        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
-        "symbol": "cCOP"
-      },
-      {
-        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-        "symbol": "cGHS"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCOP-cNGN",
-    "assets": [
-      {
-        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
-        "symbol": "cCOP"
-      },
-      {
-        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-        "symbol": "cNGN"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cGBP-cGHS",
-    "assets": [
-      {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
-      },
-      {
-        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-        "symbol": "cGHS"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cGHS-cZAR",
-    "assets": [
-      {
-        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-        "symbol": "cGHS"
-      },
-      {
-        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCAD-cGHS",
-    "assets": [
-      {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
-      },
-      {
-        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-        "symbol": "cGHS"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cGHS",
-    "assets": [
-      {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-        "symbol": "cGHS"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCHF-cGHS",
-    "assets": [
-      {
-        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-        "symbol": "cCHF"
-      },
-      {
-        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-        "symbol": "cGHS"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        }
-      ]
-    }
-  },
-  {
-    "id": "cGBP-cNGN",
-    "assets": [
-      {
-        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-        "symbol": "cGBP"
-      },
-      {
-        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-        "symbol": "cNGN"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cNGN-cZAR",
-    "assets": [
-      {
-        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-        "symbol": "cNGN"
-      },
-      {
-        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-        "symbol": "cZAR"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCAD-cNGN",
-    "assets": [
-      {
-        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-        "symbol": "cCAD"
-      },
-      {
-        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-        "symbol": "cNGN"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xff4Ab19391af240c311c54200a492233052B6325"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cAUD-cNGN",
-    "assets": [
-      {
-        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-        "symbol": "cAUD"
-      },
-      {
-        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-        "symbol": "cNGN"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x7175504C455076F15c04A2F90a8e352281F492F9"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cCHF-cNGN",
-    "assets": [
-      {
-        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-        "symbol": "cCHF"
-      },
-      {
-        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-        "symbol": "cNGN"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.297,
-      "hops": [
-        {
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
-          "spreadPercent": 0.3
-        },
-        {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cGHS-cKES",
-    "assets": [
-      {
-        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-        "symbol": "cGHS"
-      },
-      {
-        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
-        "symbol": "cKES"
-      }
-    ],
-    "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
         "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
@@ -6008,69 +6460,17 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
         ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
-        ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 1.99,
+      "totalSpreadPercent": 1.495,
       "hops": [
         {
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
+          "spreadPercent": 0.5
         },
         {
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
-          "spreadPercent": 1
-        }
-      ]
-    }
-  },
-  {
-    "id": "cKES-cNGN",
-    "assets": [
-      {
-        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
-        "symbol": "cKES"
-      },
-      {
-        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-        "symbol": "cNGN"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
-        "assets": [
-          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 1.99,
-      "hops": [
-        {
           "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
-          "spreadPercent": 1
-        },
-        {
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
           "spreadPercent": 1
         }
       ]
@@ -6121,6 +6521,346 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     }
   },
   {
+    "id": "cGHS-cKES",
+    "assets": [
+      {
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
+      },
+      {
+        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+        "symbol": "cKES"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.99,
+      "hops": [
+        {
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "cKES-cNGN",
+    "assets": [
+      {
+        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+        "symbol": "cKES"
+      },
+      {
+        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+        "symbol": "cNGN"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 1.99,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "cUSD-eXOF",
+    "assets": [
+      {
+        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+        "symbol": "cUSD"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2,
+      "hops": [
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "USDC-eXOF",
+    "assets": [
+      {
+        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2,
+      "hops": [
+        {
+          "exchangeId": "0xacc988382b66ee5456086643dcfd9a5ca43dd8f428f6ef22503d8b8013bcffd7",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "axlUSDC-eXOF",
+    "assets": [
+      {
+        "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+        "symbol": "axlUSDC"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2,
+      "hops": [
+        {
+          "exchangeId": "0x0d739efbfc30f303e8d1976c213b4040850d1af40f174f4169b846f6fd3d2f20",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "USD₮-eXOF",
+    "assets": [
+      {
+        "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+        "symbol": "USD₮"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2,
+      "hops": [
+        {
+          "exchangeId": "0x773bcec109cee923b5e04706044fd9d6a5121b1a6a4c059c36fdbe5b845d4e9b",
+          "spreadPercent": 0
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cAUD-eXOF",
+    "assets": [
+      {
+        "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+        "symbol": "cAUD"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x7175504C455076F15c04A2F90a8e352281F492F9"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.147,
+      "hops": [
+        {
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCAD-eXOF",
+    "assets": [
+      {
+        "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+        "symbol": "cCAD"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xff4Ab19391af240c311c54200a492233052B6325"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.147,
+      "hops": [
+        {
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee",
+          "spreadPercent": 0.15
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
     "id": "CELO-eXOF",
     "assets": [
       {
@@ -6135,82 +6875,18 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
         "assets": [
-          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 2,
-      "hops": [
-        {
-          "exchangeId": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-          "spreadPercent": 2
-        }
-      ]
-    }
-  },
-  {
-    "id": "axlEUROC-eXOF",
-    "assets": [
-      {
-        "address": "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d",
-        "symbol": "axlEUROC"
-      },
-      {
-        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-        "symbol": "eXOF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xcc68743c58a31c4ec3c56bca3d579409b4e2424e5f37e54a85f917b22af74e7c",
-        "assets": [
-          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-          "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 2,
-      "hops": [
-        {
-          "exchangeId": "0xcc68743c58a31c4ec3c56bca3d579409b4e2424e5f37e54a85f917b22af74e7c",
-          "spreadPercent": 2
-        }
-      ]
-    }
-  },
-  {
-    "id": "cEUR-eXOF",
-    "assets": [
-      {
-        "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-        "symbol": "cEUR"
-      },
-      {
-        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-        "symbol": "eXOF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
-        "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "0x471EcE3750Da237f93B8E339c536989b8978a438"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
         "assets": [
-          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
         ]
       }
     ],
@@ -6218,11 +6894,275 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       "totalSpreadPercent": 2.245,
       "hops": [
         {
-          "exchangeId": "0xb73ffc6b5123de3c8e460490543ab93a3be7d70824f1666343df49e219199b8c",
+          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
           "spreadPercent": 0.25
         },
         {
-          "exchangeId": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cGBP-eXOF",
+    "assets": [
+      {
+        "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+        "symbol": "cGBP"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xCCF663b1fF11028f0b19058d0f7B674004a40746"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.294,
+      "hops": [
+        {
+          "exchangeId": "0x6c369bfb1598b2f7718671221bc524c84874ad1ed7ba02a61121e7a06722e2ce",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cZAR-eXOF",
+    "assets": [
+      {
+        "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+        "symbol": "cZAR"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.294,
+      "hops": [
+        {
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCHF-eXOF",
+    "assets": [
+      {
+        "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        "symbol": "cCHF"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xb55a79F398E759E43C95b979163f30eC87Ee131D"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.294,
+      "hops": [
+        {
+          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "PUSO-eXOF",
+    "assets": [
+      {
+        "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+        "symbol": "PUSO"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.294,
+      "hops": [
+        {
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cJPY-eXOF",
+    "assets": [
+      {
+        "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+        "symbol": "cJPY"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.294,
+      "hops": [
+        {
+          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cCOP-eXOF",
+    "assets": [
+      {
+        "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+        "symbol": "cCOP"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x8A567e2aE79CA692Bd748aB832081C45de4041eA"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.294,
+      "hops": [
+        {
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b",
+          "spreadPercent": 0.3
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
           "spreadPercent": 2
         }
       ]
@@ -6243,75 +7183,31 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-        "assets": [
-          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-        "assets": [
-          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      }
-    ],
-    "spreadData": {
-      "totalSpreadPercent": 2.245,
-      "hops": [
-        {
-          "exchangeId": "0xed0528e42b9ecae538aab34b93813e08de03f8ac4a894b277ef193e67275bbae",
-          "spreadPercent": 0.25
-        },
-        {
-          "exchangeId": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-          "spreadPercent": 2
-        }
-      ]
-    }
-  },
-  {
-    "id": "cUSD-eXOF",
-    "assets": [
-      {
-        "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-        "symbol": "cUSD"
-      },
-      {
-        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-        "symbol": "eXOF"
-      }
-    ],
-    "path": [
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-        "assets": [
-          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
-        ]
-      },
-      {
-        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
+        "id": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
         "assets": [
           "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 2.245,
+      "totalSpreadPercent": 2.294,
       "hops": [
         {
-          "exchangeId": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-          "spreadPercent": 2
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05",
+          "spreadPercent": 0.3
         },
         {
-          "exchangeId": "0x3135b662c38265d0655177091f1b647b4fef511103d06c016efdf18b46930d2c",
-          "spreadPercent": 0.25
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
         }
       ]
     }
@@ -6331,18 +7227,18 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48",
+        "id": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
         "assets": [
-          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xcc68743c58a31c4ec3c56bca3d579409b4e2424e5f37e54a85f917b22af74e7c",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
         "assets": [
-          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-          "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
         ]
       }
     ],
@@ -6350,55 +7246,143 @@ export const tradablePairs42220: TradablePairWithSpread[] = [
       "totalSpreadPercent": 2.49,
       "hops": [
         {
-          "exchangeId": "0xfca6d94b46122eb9a4b86cf9d3e1e856fea8a826d0fc26c5baf17c43fbaf0f48",
+          "exchangeId": "0x746455363e8f55d04e0a2cc040d1b348a6c031b336ba6af6ae91515c194929c8",
           "spreadPercent": 0.5
         },
         {
-          "exchangeId": "0xcc68743c58a31c4ec3c56bca3d579409b4e2424e5f37e54a85f917b22af74e7c",
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
           "spreadPercent": 2
         }
       ]
     }
   },
   {
-    "id": "CELO-axlEUROC",
+    "id": "cGHS-eXOF",
     "assets": [
       {
-        "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-        "symbol": "CELO"
+        "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+        "symbol": "cGHS"
       },
       {
-        "address": "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d",
-        "symbol": "axlEUROC"
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
       }
     ],
     "path": [
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
+        "id": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
         "assets": [
-          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-          "0x471EcE3750Da237f93B8E339c536989b8978a438"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313"
         ]
       },
       {
         "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
-        "id": "0xcc68743c58a31c4ec3c56bca3d579409b4e2424e5f37e54a85f917b22af74e7c",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
         "assets": [
-          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-          "0x061cc5a2C863E0C1Cb404006D559dB18A34C762d"
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
         ]
       }
     ],
     "spreadData": {
-      "totalSpreadPercent": 3.96,
+      "totalSpreadPercent": 2.98,
       "hops": [
         {
-          "exchangeId": "0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07",
-          "spreadPercent": 2
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187",
+          "spreadPercent": 1
         },
         {
-          "exchangeId": "0xcc68743c58a31c4ec3c56bca3d579409b4e2424e5f37e54a85f917b22af74e7c",
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cNGN-eXOF",
+    "assets": [
+      {
+        "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+        "symbol": "cNGN"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.98,
+      "hops": [
+        {
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+          "spreadPercent": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "cKES-eXOF",
+    "assets": [
+      {
+        "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+        "symbol": "cKES"
+      },
+      {
+        "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+        "symbol": "eXOF"
+      }
+    ],
+    "path": [
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0"
+        ]
+      },
+      {
+        "providerAddr": "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901",
+        "id": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
+        "assets": [
+          "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08"
+        ]
+      }
+    ],
+    "spreadData": {
+      "totalSpreadPercent": 2.98,
+      "hops": [
+        {
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b",
+          "spreadPercent": 1
+        },
+        {
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b",
           "spreadPercent": 2
         }
       ]

--- a/src/constants/tradablePairs.44787.ts
+++ b/src/constants/tradablePairs.44787.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on 2025-06-26T16:12:28.767Z
+// Generated on 2025-07-11T11:12:19.594Z
 
 import { TradablePairWithSpread } from './tradablePairs'
 

--- a/src/routeFetching.test.ts
+++ b/src/routeFetching.test.ts
@@ -201,35 +201,6 @@ describe('Route Fetching Logic', () => {
   })
 
   describe('Route Display Functionality', () => {
-    it('should correctly display multi-hop route through CELO hub', async () => {
-      // Find the cUSD-eXOF route that goes through CELO
-      const cUsdToExof = await mento.findPairForTokens(TOKENS.cUSD, TOKENS.eXOF)
-
-      // Verify this is a multi-hop route
-      expect(cUsdToExof.path.length).toBe(2)
-
-      // Verify it goes through CELO as intermediate token
-      expect(hasIntermediateToken(cUsdToExof, TOKENS.CELO)).toBe(true)
-
-      // Test route display in both directions
-      const cUsdToExofDisplay = buildRouteDisplay(
-        cUsdToExof,
-        'cUSD',
-        'eXOF',
-        allPairs
-      )
-      const exofToCUsdDisplay = buildRouteDisplay(
-        cUsdToExof,
-        'eXOF',
-        'cUSD',
-        allPairs
-      )
-
-      // Both should show CELO as the intermediate token
-      expect(cUsdToExofDisplay).toBe('cUSD → CELO → eXOF')
-      expect(exofToCUsdDisplay).toBe('eXOF → CELO → cUSD')
-    })
-
     it('should correctly display direct routes', async () => {
       // Find a direct route (single hop)
       const usdcToUsdt = await mento.findPairForTokens(TOKENS.USDC, TOKENS.USDT)


### PR DESCRIPTION
**Description**
This adds the new pairs after executing the pool restructuring on mainnet and running the `cacheTradablePairs` script.

**Other changes**
Deleted the multi-hop unit test through CELO that is no longer relevant (as the only CELO pool right now is cUSD<>CELO)

**Tested**
Will deploy this on mento-web after this is merged