### PR TITLE
fix: validate chainId in Mento.create()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,15 @@ export class Mento {
    * @returns A new Mento instance
    */
   public static async create(chainId: number, rpcUrl?: string): Promise<Mento> {
+    // Validate chainId is supported
+    const supportedChainIds = Object.values(ChainId).filter((v) => typeof v === 'number') as number[]
+    if (!supportedChainIds.includes(chainId)) {
+      throw new Error(
+        `ChainId ${chainId} is not supported. ` +
+          `Supported chains: ${supportedChainIds.map((id) => `${id} (${ChainId[id]})`).join(', ')}`
+      )
+    }
+
     // Use provided RPC URL or default for the chain
     const transport = http(rpcUrl || getDefaultRpcUrl(chainId))
 


### PR DESCRIPTION
Add early validation for chainId to provide a clear error message when an unsupported chain is used.

Changes:
- Validate chainId against supported chains (CELO, CELO_SEPOLIA)
- Provide helpful error message listing supported chains

Fixes #108