### PR TITLE
fix: validate route path length in getIntermediateToken

### DIFF
--- a/src/utils/routeUtils.ts
+++ b/src/utils/routeUtils.ts
@@ -464,6 +464,11 @@ export function selectBestRoute(candidates: Route[], addrToSymbol: Map<Address, 
  * In a two-hop route A->B->C, this function finds token B (the intermediate).
  */
 export function getIntermediateToken(route: Route): Address | undefined {
+  // Only two-hop routes have intermediate tokens
+  if (route.path.length !== 2) {
+    return undefined
+  }
+
   // Find the common token between the two hops
   const [hop1, hop2] = route.path
   const hop1Tokens = [hop1.token0, hop1.token1]


### PR DESCRIPTION
Previously, getIntermediateToken assumed route.path had exactly 2 hops, causing errors when called with direct (1-hop) routes.

Changes:
- Return undefined for routes with path.length !== 2
- Prevents TypeError when destructuring

Fixes #109