### PR TITLE
fix: bump sdk to 3.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [


### PR DESCRIPTION
Accidentally published a outdated version with 3.2.2 so need to bump it againm