### PR TITLE
feat: add support for JPYm & CHFm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "3.2.6-beta.1",
+  "version": "3.2.6-beta.2",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "3.2.5",
+  "version": "3.2.6-beta.1",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "3.2.6-beta.3",
+  "version": "3.2.6",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "3.2.6-beta.2",
+  "version": "3.2.6-beta.3",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/src/cache/routes.ts
+++ b/src/cache/routes.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on 2026-04-16T14:27:24.306Z
+// Generated on 2026-04-23T15:34:57.091Z
 
 import type { RouteWithCost } from '../core/types'
 
@@ -682,30 +682,30 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "AUSD-USDC",
+      "id": "AUSD-USDT0",
       "tokens": [
         {
           "address": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
           "symbol": "AUSD"
         },
         {
-          "address": "0x534b2f3A21130d7a60830c2Df862319e593943A3",
-          "symbol": "USDC"
+          "address": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
+          "symbol": "USDT0"
         }
       ],
       "path": [
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
-          "token0": "0x534b2f3A21130d7a60830c2Df862319e593943A3",
+          "poolAddr": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
+          "token0": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
           "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
           "poolType": "FPMM"
         },
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
-          "token0": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
-          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolAddr": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
           "poolType": "FPMM"
         }
       ],
@@ -713,11 +713,11 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "totalCostPercent": 0.099975,
         "hops": [
           {
-            "poolAddress": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
+            "poolAddress": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
             "costPercent": 0.05
           },
           {
-            "poolAddress": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
+            "poolAddress": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
             "costPercent": 0.05
           }
         ]
@@ -912,6 +912,48 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "EURm-USDC",
+      "tokens": [
+        {
+          "address": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "symbol": "EURm"
+        },
+        {
+          "address": "0x534b2f3A21130d7a60830c2Df862319e593943A3",
+          "symbol": "USDC"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
+          "token0": "0x534b2f3A21130d7a60830c2Df862319e593943A3",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.199925,
+        "hops": [
+          {
+            "poolAddress": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
       "id": "AUSD-EURm",
       "tokens": [
         {
@@ -1010,16 +1052,16 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       "path": [
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
-          "token0": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
-          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
           "poolType": "FPMM"
         },
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
-          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+          "token0": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
           "poolType": "FPMM"
         }
       ],
@@ -1027,11 +1069,11 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "totalCostPercent": 0.299775,
         "hops": [
           {
-            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+            "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
             "costPercent": 0.15
           },
           {
-            "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
             "costPercent": 0.15
           }
         ]
@@ -8333,6 +8375,68 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-USDm",
+      "tokens": [
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "symbol": "USDm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.3,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-USDm",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "symbol": "USDm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.3,
+        "hops": [
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "PHPm-USDm",
       "tokens": [
         {
@@ -8391,70 +8495,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "hops": [
           {
             "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-USDm",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "symbol": "USDm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.3,
-        "hops": [
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-USDm",
-      "tokens": [
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "symbol": "USDm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.3,
-        "hops": [
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
             "costPercent": 0.3
           }
         ]
@@ -8651,6 +8691,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-axlUSDC",
+      "tokens": [
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x6285De9DA7C1d329C0451628638908915002d9d1",
+          "symbol": "axlUSDC"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xF1B77Ffc1F71b21b6c69876CEDAf82340803dE75",
+          "token0": "0x6285De9DA7C1d329C0451628638908915002d9d1",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.34985,
+        "hops": [
+          {
+            "poolAddress": "0xF1B77Ffc1F71b21b6c69876CEDAf82340803dE75",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-axlUSDC",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x6285De9DA7C1d329C0451628638908915002d9d1",
+          "symbol": "axlUSDC"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xF1B77Ffc1F71b21b6c69876CEDAf82340803dE75",
+          "token0": "0x6285De9DA7C1d329C0451628638908915002d9d1",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.34985,
+        "hops": [
+          {
+            "poolAddress": "0xF1B77Ffc1F71b21b6c69876CEDAf82340803dE75",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "PHPm-axlUSDC",
       "tokens": [
         {
@@ -8731,92 +8855,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-axlUSDC",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x6285De9DA7C1d329C0451628638908915002d9d1",
-          "symbol": "axlUSDC"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xF1B77Ffc1F71b21b6c69876CEDAf82340803dE75",
-          "token0": "0x6285De9DA7C1d329C0451628638908915002d9d1",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.34985,
-        "hops": [
-          {
-            "poolAddress": "0xF1B77Ffc1F71b21b6c69876CEDAf82340803dE75",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-axlUSDC",
-      "tokens": [
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0x6285De9DA7C1d329C0451628638908915002d9d1",
-          "symbol": "axlUSDC"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xF1B77Ffc1F71b21b6c69876CEDAf82340803dE75",
-          "token0": "0x6285De9DA7C1d329C0451628638908915002d9d1",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.34985,
-        "hops": [
-          {
-            "poolAddress": "0xF1B77Ffc1F71b21b6c69876CEDAf82340803dE75",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
             "costPercent": 0.3
           }
         ]
@@ -8909,6 +8947,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-USDC",
+      "tokens": [
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x01C5C0122039549AD1493B8220cABEdD739BC44E",
+          "symbol": "USDC"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
+          "token0": "0x01C5C0122039549AD1493B8220cABEdD739BC44E",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.34985,
+        "hops": [
+          {
+            "poolAddress": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-USDC",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x01C5C0122039549AD1493B8220cABEdD739BC44E",
+          "symbol": "USDC"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
+          "token0": "0x01C5C0122039549AD1493B8220cABEdD739BC44E",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.34985,
+        "hops": [
+          {
+            "poolAddress": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "PHPm-USDC",
       "tokens": [
         {
@@ -8989,92 +9111,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-USDC",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x01C5C0122039549AD1493B8220cABEdD739BC44E",
-          "symbol": "USDC"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
-          "token0": "0x01C5C0122039549AD1493B8220cABEdD739BC44E",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.34985,
-        "hops": [
-          {
-            "poolAddress": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-USDC",
-      "tokens": [
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0x01C5C0122039549AD1493B8220cABEdD739BC44E",
-          "symbol": "USDC"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
-          "token0": "0x01C5C0122039549AD1493B8220cABEdD739BC44E",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.34985,
-        "hops": [
-          {
-            "poolAddress": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
             "costPercent": 0.3
           }
         ]
@@ -9167,6 +9203,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-USD₮",
+      "tokens": [
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0xd077A400968890Eacc75cdc901F0356c943e4fDb",
+          "symbol": "USD₮"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xd1a70F43B2A95384DD2a7D7b259293328B3974f8",
+          "token0": "0xd077A400968890Eacc75cdc901F0356c943e4fDb",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.34985,
+        "hops": [
+          {
+            "poolAddress": "0xd1a70F43B2A95384DD2a7D7b259293328B3974f8",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-USD₮",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xd077A400968890Eacc75cdc901F0356c943e4fDb",
+          "symbol": "USD₮"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xd1a70F43B2A95384DD2a7D7b259293328B3974f8",
+          "token0": "0xd077A400968890Eacc75cdc901F0356c943e4fDb",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.34985,
+        "hops": [
+          {
+            "poolAddress": "0xd1a70F43B2A95384DD2a7D7b259293328B3974f8",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "PHPm-USD₮",
       "tokens": [
         {
@@ -9247,92 +9367,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-USD₮",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0xd077A400968890Eacc75cdc901F0356c943e4fDb",
-          "symbol": "USD₮"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xd1a70F43B2A95384DD2a7D7b259293328B3974f8",
-          "token0": "0xd077A400968890Eacc75cdc901F0356c943e4fDb",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.34985,
-        "hops": [
-          {
-            "poolAddress": "0xd1a70F43B2A95384DD2a7D7b259293328B3974f8",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-USD₮",
-      "tokens": [
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0xd077A400968890Eacc75cdc901F0356c943e4fDb",
-          "symbol": "USD₮"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xd1a70F43B2A95384DD2a7D7b259293328B3974f8",
-          "token0": "0xd077A400968890Eacc75cdc901F0356c943e4fDb",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.34985,
-        "hops": [
-          {
-            "poolAddress": "0xd1a70F43B2A95384DD2a7D7b259293328B3974f8",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
             "costPercent": 0.3
           }
         ]
@@ -9597,6 +9631,178 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "AUDm-JPYm",
+      "tokens": [
+        {
+          "address": "0x5873Faeb42F3563dcD77F0fbbdA818E6d6DA3139",
+          "symbol": "AUDm"
+        },
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x8103Fb2db87AC96cc62FAA399B98e1173720aB19",
+          "token0": "0x5873Faeb42F3563dcD77F0fbbdA818E6d6DA3139",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.44955,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x8103Fb2db87AC96cc62FAA399B98e1173720aB19",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "CADm-JPYm",
+      "tokens": [
+        {
+          "address": "0xF151c9a13b78C84f93f50B8b3bC689fedc134F60",
+          "symbol": "CADm"
+        },
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x62722497dc8992337117ee79A02015dcEa43b2C2",
+          "token0": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "token1": "0xF151c9a13b78C84f93f50B8b3bC689fedc134F60",
+          "poolType": "Virtual",
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.44955,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x62722497dc8992337117ee79A02015dcEa43b2C2",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "AUDm-CHFm",
+      "tokens": [
+        {
+          "address": "0x5873Faeb42F3563dcD77F0fbbdA818E6d6DA3139",
+          "symbol": "AUDm"
+        },
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x8103Fb2db87AC96cc62FAA399B98e1173720aB19",
+          "token0": "0x5873Faeb42F3563dcD77F0fbbdA818E6d6DA3139",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.44955,
+        "hops": [
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x8103Fb2db87AC96cc62FAA399B98e1173720aB19",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "CADm-CHFm",
+      "tokens": [
+        {
+          "address": "0xF151c9a13b78C84f93f50B8b3bC689fedc134F60",
+          "symbol": "CADm"
+        },
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x62722497dc8992337117ee79A02015dcEa43b2C2",
+          "token0": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "token1": "0xF151c9a13b78C84f93f50B8b3bC689fedc134F60",
+          "poolType": "Virtual",
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.44955,
+        "hops": [
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x62722497dc8992337117ee79A02015dcEa43b2C2",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
       "id": "AUDm-PHPm",
       "tokens": [
         {
@@ -9729,94 +9935,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "AUDm-CHFm",
-      "tokens": [
-        {
-          "address": "0x5873Faeb42F3563dcD77F0fbbdA818E6d6DA3139",
-          "symbol": "AUDm"
-        },
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x8103Fb2db87AC96cc62FAA399B98e1173720aB19",
-          "token0": "0x5873Faeb42F3563dcD77F0fbbdA818E6d6DA3139",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.44955,
-        "hops": [
-          {
-            "poolAddress": "0x8103Fb2db87AC96cc62FAA399B98e1173720aB19",
-            "costPercent": 0.15
-          },
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "AUDm-JPYm",
-      "tokens": [
-        {
-          "address": "0x5873Faeb42F3563dcD77F0fbbdA818E6d6DA3139",
-          "symbol": "AUDm"
-        },
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x8103Fb2db87AC96cc62FAA399B98e1173720aB19",
-          "token0": "0x5873Faeb42F3563dcD77F0fbbdA818E6d6DA3139",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.44955,
-        "hops": [
-          {
-            "poolAddress": "0x8103Fb2db87AC96cc62FAA399B98e1173720aB19",
-            "costPercent": 0.15
-          },
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
       "id": "AUDm-COPm",
       "tokens": [
         {
@@ -9943,94 +10061,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CADm-CHFm",
-      "tokens": [
-        {
-          "address": "0xF151c9a13b78C84f93f50B8b3bC689fedc134F60",
-          "symbol": "CADm"
-        },
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x62722497dc8992337117ee79A02015dcEa43b2C2",
-          "token0": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "token1": "0xF151c9a13b78C84f93f50B8b3bC689fedc134F60",
-          "poolType": "Virtual",
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.44955,
-        "hops": [
-          {
-            "poolAddress": "0x62722497dc8992337117ee79A02015dcEa43b2C2",
-            "costPercent": 0.15
-          },
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CADm-JPYm",
-      "tokens": [
-        {
-          "address": "0xF151c9a13b78C84f93f50B8b3bC689fedc134F60",
-          "symbol": "CADm"
-        },
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x62722497dc8992337117ee79A02015dcEa43b2C2",
-          "token0": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "token1": "0xF151c9a13b78C84f93f50B8b3bC689fedc134F60",
-          "poolType": "Virtual",
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.44955,
-        "hops": [
-          {
-            "poolAddress": "0x62722497dc8992337117ee79A02015dcEa43b2C2",
-            "costPercent": 0.15
-          },
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
             "costPercent": 0.3
           }
         ]
@@ -10198,6 +10228,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "EURm-JPYm",
+      "tokens": [
+        {
+          "address": "0xA99dC247d6b7B2E3ab48a1fEE101b83cD6aCd82a",
+          "symbol": "EURm"
+        },
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x3a58ACdd4627478581960f366fF411E11349FcB3",
+          "token0": "0xA99dC247d6b7B2E3ab48a1fEE101b83cD6aCd82a",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.54925,
+        "hops": [
+          {
+            "poolAddress": "0x3a58ACdd4627478581960f366fF411E11349FcB3",
+            "costPercent": 0.25
+          },
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-EURm",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xA99dC247d6b7B2E3ab48a1fEE101b83cD6aCd82a",
+          "symbol": "EURm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x3a58ACdd4627478581960f366fF411E11349FcB3",
+          "token0": "0xA99dC247d6b7B2E3ab48a1fEE101b83cD6aCd82a",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.54925,
+        "hops": [
+          {
+            "poolAddress": "0x3a58ACdd4627478581960f366fF411E11349FcB3",
+            "costPercent": 0.25
+          },
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "EURm-PHPm",
       "tokens": [
         {
@@ -10278,92 +10392,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-EURm",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0xA99dC247d6b7B2E3ab48a1fEE101b83cD6aCd82a",
-          "symbol": "EURm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x3a58ACdd4627478581960f366fF411E11349FcB3",
-          "token0": "0xA99dC247d6b7B2E3ab48a1fEE101b83cD6aCd82a",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.54925,
-        "hops": [
-          {
-            "poolAddress": "0x3a58ACdd4627478581960f366fF411E11349FcB3",
-            "costPercent": 0.25
-          },
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "EURm-JPYm",
-      "tokens": [
-        {
-          "address": "0xA99dC247d6b7B2E3ab48a1fEE101b83cD6aCd82a",
-          "symbol": "EURm"
-        },
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x3a58ACdd4627478581960f366fF411E11349FcB3",
-          "token0": "0xA99dC247d6b7B2E3ab48a1fEE101b83cD6aCd82a",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.54925,
-        "hops": [
-          {
-            "poolAddress": "0x3a58ACdd4627478581960f366fF411E11349FcB3",
-            "costPercent": 0.25
-          },
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
             "costPercent": 0.3
           }
         ]
@@ -10456,6 +10484,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "GBPm-JPYm",
+      "tokens": [
+        {
+          "address": "0x85F5181Abdbf0e1814Fc4358582Ae07b8eBA3aF3",
+          "symbol": "GBPm"
+        },
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+          "token0": "0x85F5181Abdbf0e1814Fc4358582Ae07b8eBA3aF3",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-GBPm",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x85F5181Abdbf0e1814Fc4358582Ae07b8eBA3aF3",
+          "symbol": "GBPm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+          "token0": "0x85F5181Abdbf0e1814Fc4358582Ae07b8eBA3aF3",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "GBPm-PHPm",
       "tokens": [
         {
@@ -10536,92 +10648,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-GBPm",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x85F5181Abdbf0e1814Fc4358582Ae07b8eBA3aF3",
-          "symbol": "GBPm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
-          "token0": "0x85F5181Abdbf0e1814Fc4358582Ae07b8eBA3aF3",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "GBPm-JPYm",
-      "tokens": [
-        {
-          "address": "0x85F5181Abdbf0e1814Fc4358582Ae07b8eBA3aF3",
-          "symbol": "GBPm"
-        },
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
-          "token0": "0x85F5181Abdbf0e1814Fc4358582Ae07b8eBA3aF3",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
             "costPercent": 0.3
           }
         ]
@@ -10714,6 +10740,392 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "CHFm-JPYm",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "JPYm-PHPm",
+      "tokens": [
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x0352976d940a2C3FBa0C3623198947Ee1d17869E",
+          "symbol": "PHPm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x671334256a893fDBc4FfE55F98f156A168bD897a",
+          "token0": "0x0352976d940a2C3FBa0C3623198947Ee1d17869E",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x671334256a893fDBc4FfE55F98f156A168bD897a",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "JPYm-ZARm",
+      "tokens": [
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x10CCfB235b0E1Ed394bACE4560C3ed016697687e",
+          "symbol": "ZARm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
+          "token0": "0x10CCfB235b0E1Ed394bACE4560C3ed016697687e",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "COPm-JPYm",
+      "tokens": [
+        {
+          "address": "0x5F8d55c3627d2dc0a2B4afa798f877242F382F67",
+          "symbol": "COPm"
+        },
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0xCBfC8C84168D7F34FabA0018A3A63b998f1ffeCe",
+          "token0": "0x5F8d55c3627d2dc0a2B4afa798f877242F382F67",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0xCBfC8C84168D7F34FabA0018A3A63b998f1ffeCe",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "BRLm-JPYm",
+      "tokens": [
+        {
+          "address": "0x2294298942fdc79417DE9E0D740A4957E0e7783a",
+          "symbol": "BRLm"
+        },
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x49A968C539599385c69c2d528500DA58d933FafA",
+          "token0": "0x2294298942fdc79417DE9E0D740A4957E0e7783a",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x49A968C539599385c69c2d528500DA58d933FafA",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-PHPm",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x0352976d940a2C3FBa0C3623198947Ee1d17869E",
+          "symbol": "PHPm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x671334256a893fDBc4FfE55F98f156A168bD897a",
+          "token0": "0x0352976d940a2C3FBa0C3623198947Ee1d17869E",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x671334256a893fDBc4FfE55F98f156A168bD897a",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-ZARm",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x10CCfB235b0E1Ed394bACE4560C3ed016697687e",
+          "symbol": "ZARm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
+          "token0": "0x10CCfB235b0E1Ed394bACE4560C3ed016697687e",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-COPm",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x5F8d55c3627d2dc0a2B4afa798f877242F382F67",
+          "symbol": "COPm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0xCBfC8C84168D7F34FabA0018A3A63b998f1ffeCe",
+          "token0": "0x5F8d55c3627d2dc0a2B4afa798f877242F382F67",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0xCBfC8C84168D7F34FabA0018A3A63b998f1ffeCe",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "BRLm-CHFm",
+      "tokens": [
+        {
+          "address": "0x2294298942fdc79417DE9E0D740A4957E0e7783a",
+          "symbol": "BRLm"
+        },
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x49A968C539599385c69c2d528500DA58d933FafA",
+          "token0": "0x2294298942fdc79417DE9E0D740A4957E0e7783a",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x49A968C539599385c69c2d528500DA58d933FafA",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "PHPm-ZARm",
       "tokens": [
         {
@@ -10752,94 +11164,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-PHPm",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x0352976d940a2C3FBa0C3623198947Ee1d17869E",
-          "symbol": "PHPm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x671334256a893fDBc4FfE55F98f156A168bD897a",
-          "token0": "0x0352976d940a2C3FBa0C3623198947Ee1d17869E",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x671334256a893fDBc4FfE55F98f156A168bD897a",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-PHPm",
-      "tokens": [
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0x0352976d940a2C3FBa0C3623198947Ee1d17869E",
-          "symbol": "PHPm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x671334256a893fDBc4FfE55F98f156A168bD897a",
-          "token0": "0x0352976d940a2C3FBa0C3623198947Ee1d17869E",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x671334256a893fDBc4FfE55F98f156A168bD897a",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
             "costPercent": 0.3
           }
         ]
@@ -10934,94 +11258,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "CHFm-ZARm",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x10CCfB235b0E1Ed394bACE4560C3ed016697687e",
-          "symbol": "ZARm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-          "token0": "0x10CCfB235b0E1Ed394bACE4560C3ed016697687e",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-ZARm",
-      "tokens": [
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0x10CCfB235b0E1Ed394bACE4560C3ed016697687e",
-          "symbol": "ZARm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-          "token0": "0x10CCfB235b0E1Ed394bACE4560C3ed016697687e",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
       "id": "COPm-ZARm",
       "tokens": [
         {
@@ -11100,226 +11336,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "hops": [
           {
             "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x49A968C539599385c69c2d528500DA58d933FafA",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-JPYm",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-COPm",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x5F8d55c3627d2dc0a2B4afa798f877242F382F67",
-          "symbol": "COPm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0xCBfC8C84168D7F34FabA0018A3A63b998f1ffeCe",
-          "token0": "0x5F8d55c3627d2dc0a2B4afa798f877242F382F67",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0xCBfC8C84168D7F34FabA0018A3A63b998f1ffeCe",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "BRLm-CHFm",
-      "tokens": [
-        {
-          "address": "0x2294298942fdc79417DE9E0D740A4957E0e7783a",
-          "symbol": "BRLm"
-        },
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x49A968C539599385c69c2d528500DA58d933FafA",
-          "token0": "0x2294298942fdc79417DE9E0D740A4957E0e7783a",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x49A968C539599385c69c2d528500DA58d933FafA",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "COPm-JPYm",
-      "tokens": [
-        {
-          "address": "0x5F8d55c3627d2dc0a2B4afa798f877242F382F67",
-          "symbol": "COPm"
-        },
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0xCBfC8C84168D7F34FabA0018A3A63b998f1ffeCe",
-          "token0": "0x5F8d55c3627d2dc0a2B4afa798f877242F382F67",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0xCBfC8C84168D7F34FabA0018A3A63b998f1ffeCe",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "BRLm-JPYm",
-      "tokens": [
-        {
-          "address": "0x2294298942fdc79417DE9E0D740A4957E0e7783a",
-          "symbol": "BRLm"
-        },
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x49A968C539599385c69c2d528500DA58d933FafA",
-          "token0": "0x2294298942fdc79417DE9E0D740A4957E0e7783a",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
             "costPercent": 0.3
           },
           {
@@ -12421,6 +12437,264 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "GHSm-JPYm",
+      "tokens": [
+        {
+          "address": "0x5e94B8C872bD47BC4255E60ECBF44D5E66e7401C",
+          "symbol": "GHSm"
+        },
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x917eE035bF0A964ACC75539f919A5B4F16336373",
+          "token0": "0x5e94B8C872bD47BC4255E60ECBF44D5E66e7401C",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 1.297,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x917eE035bF0A964ACC75539f919A5B4F16336373",
+            "costPercent": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "JPYm-NGNm",
+      "tokens": [
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x3d5ae86F34E2a82771496D140daFAEf3789dF888",
+          "symbol": "NGNm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x6B66271811615F4b6daDb8620ED71a1E90f41Deb",
+          "token0": "0x3d5ae86F34E2a82771496D140daFAEf3789dF888",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 1.297,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x6B66271811615F4b6daDb8620ED71a1E90f41Deb",
+            "costPercent": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "JPYm-KESm",
+      "tokens": [
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0xC7e4635651E3e3Af82b61d3E23c159438daE3BbF",
+          "symbol": "KESm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x22118009665B1d6810d4560A098D3E67bbcb934f",
+          "token0": "0xC7e4635651E3e3Af82b61d3E23c159438daE3BbF",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 1.297,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x22118009665B1d6810d4560A098D3E67bbcb934f",
+            "costPercent": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-GHSm",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x5e94B8C872bD47BC4255E60ECBF44D5E66e7401C",
+          "symbol": "GHSm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x917eE035bF0A964ACC75539f919A5B4F16336373",
+          "token0": "0x5e94B8C872bD47BC4255E60ECBF44D5E66e7401C",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 1.297,
+        "hops": [
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x917eE035bF0A964ACC75539f919A5B4F16336373",
+            "costPercent": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-NGNm",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x3d5ae86F34E2a82771496D140daFAEf3789dF888",
+          "symbol": "NGNm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x6B66271811615F4b6daDb8620ED71a1E90f41Deb",
+          "token0": "0x3d5ae86F34E2a82771496D140daFAEf3789dF888",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 1.297,
+        "hops": [
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x6B66271811615F4b6daDb8620ED71a1E90f41Deb",
+            "costPercent": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-KESm",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xC7e4635651E3e3Af82b61d3E23c159438daE3BbF",
+          "symbol": "KESm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x22118009665B1d6810d4560A098D3E67bbcb934f",
+          "token0": "0xC7e4635651E3e3Af82b61d3E23c159438daE3BbF",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 1.297,
+        "hops": [
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x22118009665B1d6810d4560A098D3E67bbcb934f",
+            "costPercent": 1
+          }
+        ]
+      }
+    },
+    {
       "id": "GHSm-PHPm",
       "tokens": [
         {
@@ -12675,270 +12949,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "hops": [
           {
             "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x22118009665B1d6810d4560A098D3E67bbcb934f",
-            "costPercent": 1
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-GHSm",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x5e94B8C872bD47BC4255E60ECBF44D5E66e7401C",
-          "symbol": "GHSm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x917eE035bF0A964ACC75539f919A5B4F16336373",
-          "token0": "0x5e94B8C872bD47BC4255E60ECBF44D5E66e7401C",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 1.297,
-        "hops": [
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x917eE035bF0A964ACC75539f919A5B4F16336373",
-            "costPercent": 1
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-NGNm",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x3d5ae86F34E2a82771496D140daFAEf3789dF888",
-          "symbol": "NGNm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x6B66271811615F4b6daDb8620ED71a1E90f41Deb",
-          "token0": "0x3d5ae86F34E2a82771496D140daFAEf3789dF888",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 1.297,
-        "hops": [
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x6B66271811615F4b6daDb8620ED71a1E90f41Deb",
-            "costPercent": 1
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-KESm",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0xC7e4635651E3e3Af82b61d3E23c159438daE3BbF",
-          "symbol": "KESm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x22118009665B1d6810d4560A098D3E67bbcb934f",
-          "token0": "0xC7e4635651E3e3Af82b61d3E23c159438daE3BbF",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 1.297,
-        "hops": [
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x22118009665B1d6810d4560A098D3E67bbcb934f",
-            "costPercent": 1
-          }
-        ]
-      }
-    },
-    {
-      "id": "GHSm-JPYm",
-      "tokens": [
-        {
-          "address": "0x5e94B8C872bD47BC4255E60ECBF44D5E66e7401C",
-          "symbol": "GHSm"
-        },
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x917eE035bF0A964ACC75539f919A5B4F16336373",
-          "token0": "0x5e94B8C872bD47BC4255E60ECBF44D5E66e7401C",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 1.297,
-        "hops": [
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x917eE035bF0A964ACC75539f919A5B4F16336373",
-            "costPercent": 1
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-NGNm",
-      "tokens": [
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0x3d5ae86F34E2a82771496D140daFAEf3789dF888",
-          "symbol": "NGNm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x6B66271811615F4b6daDb8620ED71a1E90f41Deb",
-          "token0": "0x3d5ae86F34E2a82771496D140daFAEf3789dF888",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 1.297,
-        "hops": [
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x6B66271811615F4b6daDb8620ED71a1E90f41Deb",
-            "costPercent": 1
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-KESm",
-      "tokens": [
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0xC7e4635651E3e3Af82b61d3E23c159438daE3BbF",
-          "symbol": "KESm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x22118009665B1d6810d4560A098D3E67bbcb934f",
-          "token0": "0xC7e4635651E3e3Af82b61d3E23c159438daE3BbF",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 1.297,
-        "hops": [
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
             "costPercent": 0.3
           },
           {
@@ -13680,6 +13690,92 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-XOFm",
+      "tokens": [
+        {
+          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x5505b70207aE3B826c1A7607F19F3Bf73444A082",
+          "symbol": "XOFm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x1e2506EdCa4eF3030E51bE8B571B935d55677604",
+          "token0": "0x5505b70207aE3B826c1A7607F19F3Bf73444A082",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 2.294,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x1e2506EdCa4eF3030E51bE8B571B935d55677604",
+            "costPercent": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-XOFm",
+      "tokens": [
+        {
+          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x5505b70207aE3B826c1A7607F19F3Bf73444A082",
+          "symbol": "XOFm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
+          "poolAddr": "0x1e2506EdCa4eF3030E51bE8B571B935d55677604",
+          "token0": "0x5505b70207aE3B826c1A7607F19F3Bf73444A082",
+          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
+          "poolType": "Virtual",
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 2.294,
+        "hops": [
+          {
+            "poolAddress": "0x938A21b1f301206aBB4e15340782b89EF7D83c9c",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x1e2506EdCa4eF3030E51bE8B571B935d55677604",
+            "costPercent": 2
+          }
+        ]
+      }
+    },
+    {
       "id": "PHPm-XOFm",
       "tokens": [
         {
@@ -13762,94 +13858,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x68D19b5a48cbbFd11057E97DA9960B09D771E7B6",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-XOFm",
-      "tokens": [
-        {
-          "address": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x5505b70207aE3B826c1A7607F19F3Bf73444A082",
-          "symbol": "XOFm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x1e2506EdCa4eF3030E51bE8B571B935d55677604",
-          "token0": "0x5505b70207aE3B826c1A7607F19F3Bf73444A082",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-          "token0": "0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 2.294,
-        "hops": [
-          {
-            "poolAddress": "0x1e2506EdCa4eF3030E51bE8B571B935d55677604",
-            "costPercent": 2
-          },
-          {
-            "poolAddress": "0x58F08739eA9764097b9500B6e4A4db64D168b807",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-XOFm",
-      "tokens": [
-        {
-          "address": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0x5505b70207aE3B826c1A7607F19F3Bf73444A082",
-          "symbol": "XOFm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x1e2506EdCa4eF3030E51bE8B571B935d55677604",
-          "token0": "0x5505b70207aE3B826c1A7607F19F3Bf73444A082",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b"
-        },
-        {
-          "factoryAddr": "0x887955f28723B0e9Bddc358448CB5B1FDe692da4",
-          "poolAddr": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
-          "token0": "0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426",
-          "token1": "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 2.294,
-        "hops": [
-          {
-            "poolAddress": "0x1e2506EdCa4eF3030E51bE8B571B935d55677604",
-            "costPercent": 2
-          },
-          {
-            "poolAddress": "0x284c2d99c5A12A65F10eFF7183c33C1217B65A56",
             "costPercent": 0.3
           }
         ]

--- a/src/cache/routes.ts
+++ b/src/cache/routes.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on 2026-04-27T16:44:20.964Z
+// Generated on 2026-04-27T17:19:25.234Z
 
 import type { RouteWithCost } from '../core/types'
 
@@ -1498,30 +1498,30 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "EURm-USDC",
+      "id": "AUSD-EURm",
       "tokens": [
+        {
+          "address": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
+          "symbol": "AUSD"
+        },
         {
           "address": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
           "symbol": "EURm"
-        },
-        {
-          "address": "0x534b2f3A21130d7a60830c2Df862319e593943A3",
-          "symbol": "USDC"
         }
       ],
       "path": [
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
-          "token0": "0x534b2f3A21130d7a60830c2Df862319e593943A3",
-          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
           "poolType": "FPMM"
         },
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
-          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "poolAddr": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
+          "token0": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
           "poolType": "FPMM"
         }
       ],
@@ -1529,34 +1529,76 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "totalCostPercent": 0.199925,
         "hops": [
           {
-            "poolAddress": "0x7109E0A9B4623e90755b7e5c4e10F089E5Bf8bDb",
+            "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+            "costPercent": 0.15
+          },
+          {
+            "poolAddress": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
+            "costPercent": 0.05
+          }
+        ]
+      }
+    },
+    {
+      "id": "JPYm-USDT0",
+      "tokens": [
+        {
+          "address": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
+          "symbol": "USDT0"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.199925,
+        "hops": [
+          {
+            "poolAddress": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
             "costPercent": 0.05
           },
           {
-            "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
             "costPercent": 0.15
           }
         ]
       }
     },
     {
-      "id": "AUSD-CHFm",
+      "id": "CHFm-USDT0",
       "tokens": [
-        {
-          "address": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
-          "symbol": "AUSD"
-        },
         {
           "address": "0xCD8f6950359795eb4688AC18d1e9BB88fa111eEe",
           "symbol": "CHFm"
+        },
+        {
+          "address": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
+          "symbol": "USDT0"
         }
       ],
       "path": [
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
-          "token0": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
-          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolAddr": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
           "poolType": "FPMM"
         },
         {
@@ -1571,53 +1613,11 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "totalCostPercent": 0.199925,
         "hops": [
           {
-            "poolAddress": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
+            "poolAddress": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
             "costPercent": 0.05
           },
           {
             "poolAddress": "0x49e220DB6255061E0A49e679A115A4e6948971Ce",
-            "costPercent": 0.15
-          }
-        ]
-      }
-    },
-    {
-      "id": "EURm-GBPm",
-      "tokens": [
-        {
-          "address": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
-          "symbol": "EURm"
-        },
-        {
-          "address": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
-          "symbol": "GBPm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
-          "token0": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
-          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
-          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
-          "poolType": "FPMM"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.299775,
-        "hops": [
-          {
-            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
-            "costPercent": 0.15
-          },
-          {
-            "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
             "costPercent": 0.15
           }
         ]
@@ -1638,70 +1638,28 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       "path": [
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
           "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
           "token0": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
           "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
           "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
-          "token0": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
-          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "poolType": "FPMM"
         }
       ],
       "costData": {
         "totalCostPercent": 0.299775,
         "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.15
+          },
           {
             "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
-            "costPercent": 0.15
-          },
-          {
-            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
-            "costPercent": 0.15
-          }
-        ]
-      }
-    },
-    {
-      "id": "EURm-JPYm",
-      "tokens": [
-        {
-          "address": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
-          "symbol": "EURm"
-        },
-        {
-          "address": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
-          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
-          "token0": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
-          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "poolType": "FPMM"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.299775,
-        "hops": [
-          {
-            "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
-            "costPercent": 0.15
-          },
-          {
-            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
             "costPercent": 0.15
           }
         ]

--- a/src/cache/routes.ts
+++ b/src/cache/routes.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on 2026-04-23T15:34:57.091Z
+// Generated on 2026-04-27T16:44:20.964Z
 
 import type { RouteWithCost } from '../core/types'
 
@@ -292,6 +292,68 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-USDm",
+      "tokens": [
+        {
+          "address": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "symbol": "USDm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+          "token0": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.15,
+        "hops": [
+          {
+            "poolAddress": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-USDm",
+      "tokens": [
+        {
+          "address": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "symbol": "USDm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "token1": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.15,
+        "hops": [
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
       "id": "GBPm-USDC",
       "tokens": [
         {
@@ -460,6 +522,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-USDC",
+      "tokens": [
+        {
+          "address": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+          "symbol": "USDC"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x463c0d1F04bcd99A1efCF94AC2a75bc19Ea4A7E5",
+          "token0": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+          "token0": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.199925,
+        "hops": [
+          {
+            "poolAddress": "0x463c0d1F04bcd99A1efCF94AC2a75bc19Ea4A7E5",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-USDC",
+      "tokens": [
+        {
+          "address": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+          "symbol": "USDC"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x463c0d1F04bcd99A1efCF94AC2a75bc19Ea4A7E5",
+          "token0": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "token1": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.199925,
+        "hops": [
+          {
+            "poolAddress": "0x463c0d1F04bcd99A1efCF94AC2a75bc19Ea4A7E5",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
       "id": "AUSD-EURm",
       "tokens": [
         {
@@ -496,6 +642,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x93e15A22fDa39FEfcCCe82D387A09cCF030EAD61",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "AUSD-JPYm",
+      "tokens": [
+        {
+          "address": "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a",
+          "symbol": "AUSD"
+        },
+        {
+          "address": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xb0a0264Ce6847F101b76ba36A4a3083ba489F501",
+          "token0": "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+          "token0": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.199925,
+        "hops": [
+          {
+            "poolAddress": "0xb0a0264Ce6847F101b76ba36A4a3083ba489F501",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "AUSD-CHFm",
+      "tokens": [
+        {
+          "address": "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a",
+          "symbol": "AUSD"
+        },
+        {
+          "address": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "symbol": "CHFm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xb0a0264Ce6847F101b76ba36A4a3083ba489F501",
+          "token0": "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "token1": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.199925,
+        "hops": [
+          {
+            "poolAddress": "0xb0a0264Ce6847F101b76ba36A4a3083ba489F501",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
             "costPercent": 0.15
           }
         ]
@@ -544,6 +774,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-USDT0",
+      "tokens": [
+        {
+          "address": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+          "symbol": "USDT0"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x0A59be741AD49c6C2E0a2d30a57eD8f5ffa5DEB8",
+          "token0": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "token1": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+          "token0": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.199925,
+        "hops": [
+          {
+            "poolAddress": "0x0A59be741AD49c6C2E0a2d30a57eD8f5ffa5DEB8",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-USDT0",
+      "tokens": [
+        {
+          "address": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+          "symbol": "USDT0"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x0A59be741AD49c6C2E0a2d30a57eD8f5ffa5DEB8",
+          "token0": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "token1": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "token1": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.199925,
+        "hops": [
+          {
+            "poolAddress": "0x0A59be741AD49c6C2E0a2d30a57eD8f5ffa5DEB8",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
       "id": "EURm-GBPm",
       "tokens": [
         {
@@ -580,6 +894,216 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x93e15A22fDa39FEfcCCe82D387A09cCF030EAD61",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "GBPm-JPYm",
+      "tokens": [
+        {
+          "address": "0x39bb4E0a204412bB98e821d25e7d955e69d40Fd1",
+          "symbol": "GBPm"
+        },
+        {
+          "address": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xD0E9c1a718D2a693d41eacd4B2696180403Ce081",
+          "token0": "0x39bb4E0a204412bB98e821d25e7d955e69d40Fd1",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+          "token0": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.299775,
+        "hops": [
+          {
+            "poolAddress": "0xD0E9c1a718D2a693d41eacd4B2696180403Ce081",
+            "costPercent": 0.15
+          },
+          {
+            "poolAddress": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-GBPm",
+      "tokens": [
+        {
+          "address": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x39bb4E0a204412bB98e821d25e7d955e69d40Fd1",
+          "symbol": "GBPm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xD0E9c1a718D2a693d41eacd4B2696180403Ce081",
+          "token0": "0x39bb4E0a204412bB98e821d25e7d955e69d40Fd1",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "token1": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.299775,
+        "hops": [
+          {
+            "poolAddress": "0xD0E9c1a718D2a693d41eacd4B2696180403Ce081",
+            "costPercent": 0.15
+          },
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "EURm-JPYm",
+      "tokens": [
+        {
+          "address": "0x4D502d735B4C574B487Ed641ae87cEaE884731C7",
+          "symbol": "EURm"
+        },
+        {
+          "address": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x93e15A22fDa39FEfcCCe82D387A09cCF030EAD61",
+          "token0": "0x4D502d735B4C574B487Ed641ae87cEaE884731C7",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+          "token0": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.299775,
+        "hops": [
+          {
+            "poolAddress": "0x93e15A22fDa39FEfcCCe82D387A09cCF030EAD61",
+            "costPercent": 0.15
+          },
+          {
+            "poolAddress": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-EURm",
+      "tokens": [
+        {
+          "address": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x4D502d735B4C574B487Ed641ae87cEaE884731C7",
+          "symbol": "EURm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x93e15A22fDa39FEfcCCe82D387A09cCF030EAD61",
+          "token0": "0x4D502d735B4C574B487Ed641ae87cEaE884731C7",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "token1": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.299775,
+        "hops": [
+          {
+            "poolAddress": "0x93e15A22fDa39FEfcCCe82D387A09cCF030EAD61",
+            "costPercent": 0.15
+          },
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-JPYm",
+      "tokens": [
+        {
+          "address": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+          "token0": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+          "token1": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+          "token1": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.299775,
+        "hops": [
+          {
+            "poolAddress": "0x4DF3f08977743Ad95aB31b8dC203EAe885Ae9D32",
+            "costPercent": 0.15
+          },
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
             "costPercent": 0.15
           }
         ]
@@ -696,16 +1220,16 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       "path": [
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
-          "token0": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
-          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolAddr": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
           "poolType": "FPMM"
         },
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
-          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "token1": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
+          "poolAddr": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
+          "token0": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
           "poolType": "FPMM"
         }
       ],
@@ -713,11 +1237,11 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "totalCostPercent": 0.099975,
         "hops": [
           {
-            "poolAddress": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
+            "poolAddress": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
             "costPercent": 0.05
           },
           {
-            "poolAddress": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
+            "poolAddress": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
             "costPercent": 0.05
           }
         ]
@@ -780,6 +1304,68 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "hops": [
           {
             "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "JPYm-USDm",
+      "tokens": [
+        {
+          "address": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "symbol": "USDm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.15,
+        "hops": [
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-USDm",
+      "tokens": [
+        {
+          "address": "0xCD8f6950359795eb4688AC18d1e9BB88fa111eEe",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "symbol": "USDm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x49e220DB6255061E0A49e679A115A4e6948971Ce",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0xCD8f6950359795eb4688AC18d1e9BB88fa111eEe",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.15,
+        "hops": [
+          {
+            "poolAddress": "0x49e220DB6255061E0A49e679A115A4e6948971Ce",
             "costPercent": 0.15
           }
         ]
@@ -884,16 +1470,16 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       "path": [
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
-          "token0": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
-          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolAddr": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
           "poolType": "FPMM"
         },
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
-          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "token1": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
+          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+          "token0": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
           "poolType": "FPMM"
         }
       ],
@@ -901,12 +1487,12 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "totalCostPercent": 0.199925,
         "hops": [
           {
-            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
-            "costPercent": 0.15
-          },
-          {
             "poolAddress": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
             "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+            "costPercent": 0.15
           }
         ]
       }
@@ -954,15 +1540,15 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "AUSD-EURm",
+      "id": "AUSD-CHFm",
       "tokens": [
         {
           "address": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
           "symbol": "AUSD"
         },
         {
-          "address": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
-          "symbol": "EURm"
+          "address": "0xCD8f6950359795eb4688AC18d1e9BB88fa111eEe",
+          "symbol": "CHFm"
         }
       ],
       "path": [
@@ -975,9 +1561,9 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         },
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+          "poolAddr": "0x49e220DB6255061E0A49e679A115A4e6948971Ce",
           "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "token1": "0xCD8f6950359795eb4688AC18d1e9BB88fa111eEe",
           "poolType": "FPMM"
         }
       ],
@@ -989,49 +1575,7 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
             "costPercent": 0.05
           },
           {
-            "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
-            "costPercent": 0.15
-          }
-        ]
-      }
-    },
-    {
-      "id": "EURm-USDT0",
-      "tokens": [
-        {
-          "address": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
-          "symbol": "EURm"
-        },
-        {
-          "address": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
-          "symbol": "USDT0"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
-          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "token1": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
-          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
-          "poolType": "FPMM"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.199925,
-        "hops": [
-          {
-            "poolAddress": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+            "poolAddress": "0x49e220DB6255061E0A49e679A115A4e6948971Ce",
             "costPercent": 0.15
           }
         ]
@@ -1052,6 +1596,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       "path": [
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+          "token0": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.299775,
+        "hops": [
+          {
+            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+            "costPercent": 0.15
+          },
+          {
+            "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "GBPm-JPYm",
+      "tokens": [
+        {
+          "address": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
+          "symbol": "GBPm"
+        },
+        {
+          "address": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+          "token0": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.299775,
+        "hops": [
+          {
+            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+            "costPercent": 0.15
+          },
+          {
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "EURm-JPYm",
+      "tokens": [
+        {
+          "address": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "symbol": "EURm"
+        },
+        {
+          "address": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
           "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
           "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
           "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
@@ -1059,8 +1687,8 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         },
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
-          "token0": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
+          "poolAddr": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
+          "token0": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
           "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
           "poolType": "FPMM"
         }
@@ -1073,7 +1701,7 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
             "costPercent": 0.15
           },
           {
-            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+            "poolAddress": "0xfD5295e75Ffea02780B0e2638D9faBb0316fD4e0",
             "costPercent": 0.15
           }
         ]
@@ -1856,6 +2484,68 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-USDm",
+      "tokens": [
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "USDm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.3,
+        "hops": [
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-USDm",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "symbol": "USDm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.3,
+        "hops": [
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "USDm-ZARm",
       "tokens": [
         {
@@ -1888,38 +2578,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "CHFm-USDm",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "symbol": "USDm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.3,
-        "hops": [
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
       "id": "PHPm-USDm",
       "tokens": [
         {
@@ -1946,38 +2604,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "hops": [
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-USDm",
-      "tokens": [
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "symbol": "USDm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.3,
-        "hops": [
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           }
         ]
@@ -2174,6 +2800,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-axlUSDC",
+      "tokens": [
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xb285d4C7133d6f27BfB29224fb0D22E7EC3ddD2D",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.34985,
+        "hops": [
+          {
+            "poolAddress": "0xb285d4C7133d6f27BfB29224fb0D22E7EC3ddD2D",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-axlUSDC",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "symbol": "axlUSDC"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xb285d4C7133d6f27BfB29224fb0D22E7EC3ddD2D",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.34985,
+        "hops": [
+          {
+            "poolAddress": "0xb285d4C7133d6f27BfB29224fb0D22E7EC3ddD2D",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "ZARm-axlUSDC",
       "tokens": [
         {
@@ -2217,49 +2927,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "CHFm-axlUSDC",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-          "symbol": "axlUSDC"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
-          "poolAddr": "0xb285d4C7133d6f27BfB29224fb0D22E7EC3ddD2D",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.34985,
-        "hops": [
-          {
-            "poolAddress": "0xb285d4C7133d6f27BfB29224fb0D22E7EC3ddD2D",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
       "id": "PHPm-axlUSDC",
       "tokens": [
         {
@@ -2297,49 +2964,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-axlUSDC",
-      "tokens": [
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-          "symbol": "axlUSDC"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
-          "poolAddr": "0xb285d4C7133d6f27BfB29224fb0D22E7EC3ddD2D",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.34985,
-        "hops": [
-          {
-            "poolAddress": "0xb285d4C7133d6f27BfB29224fb0D22E7EC3ddD2D",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           }
         ]
@@ -2432,6 +3056,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-USDC",
+      "tokens": [
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x462fe04b4FD719Cbd04C0310365D421D02AaA19E",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.34985,
+        "hops": [
+          {
+            "poolAddress": "0x462fe04b4FD719Cbd04C0310365D421D02AaA19E",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-USDC",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "symbol": "USDC"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x462fe04b4FD719Cbd04C0310365D421D02AaA19E",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.34985,
+        "hops": [
+          {
+            "poolAddress": "0x462fe04b4FD719Cbd04C0310365D421D02AaA19E",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "USDC-ZARm",
       "tokens": [
         {
@@ -2475,49 +3183,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "CHFm-USDC",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-          "symbol": "USDC"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
-          "poolAddr": "0x462fe04b4FD719Cbd04C0310365D421D02AaA19E",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.34985,
-        "hops": [
-          {
-            "poolAddress": "0x462fe04b4FD719Cbd04C0310365D421D02AaA19E",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
       "id": "PHPm-USDC",
       "tokens": [
         {
@@ -2555,49 +3220,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-USDC",
-      "tokens": [
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-          "symbol": "USDC"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
-          "poolAddr": "0x462fe04b4FD719Cbd04C0310365D421D02AaA19E",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.34985,
-        "hops": [
-          {
-            "poolAddress": "0x462fe04b4FD719Cbd04C0310365D421D02AaA19E",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           }
         ]
@@ -2690,6 +3312,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-USD₮",
+      "tokens": [
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+          "symbol": "USD₮"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x0FEBa760d93423D127DE1B6ABECdB60E5253228D",
+          "token0": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.34985,
+        "hops": [
+          {
+            "poolAddress": "0x0FEBa760d93423D127DE1B6ABECdB60E5253228D",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-USD₮",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+          "symbol": "USD₮"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x0FEBa760d93423D127DE1B6ABECdB60E5253228D",
+          "token0": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.34985,
+        "hops": [
+          {
+            "poolAddress": "0x0FEBa760d93423D127DE1B6ABECdB60E5253228D",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "USD₮-ZARm",
       "tokens": [
         {
@@ -2733,49 +3439,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "CHFm-USD₮",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-          "symbol": "USD₮"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
-          "poolAddr": "0x0FEBa760d93423D127DE1B6ABECdB60E5253228D",
-          "token0": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.34985,
-        "hops": [
-          {
-            "poolAddress": "0x0FEBa760d93423D127DE1B6ABECdB60E5253228D",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
       "id": "PHPm-USD₮",
       "tokens": [
         {
@@ -2813,49 +3476,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-USD₮",
-      "tokens": [
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-          "symbol": "USD₮"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
-          "poolAddr": "0x0FEBa760d93423D127DE1B6ABECdB60E5253228D",
-          "token0": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.34985,
-        "hops": [
-          {
-            "poolAddress": "0x0FEBa760d93423D127DE1B6ABECdB60E5253228D",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           }
         ]
@@ -3120,6 +3740,178 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "AUDm-JPYm",
+      "tokens": [
+        {
+          "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+          "symbol": "AUDm"
+        },
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x1d013077b00B28038A3f1e7A29ABa34E12e562e9",
+          "token0": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "poolType": "Virtual",
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.44955,
+        "hops": [
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x1d013077b00B28038A3f1e7A29ABa34E12e562e9",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "CADm-JPYm",
+      "tokens": [
+        {
+          "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+          "symbol": "CADm"
+        },
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x62fA288e3AC844dCfcE5469af4f8feb7d6f7Ba61",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xff4Ab19391af240c311c54200a492233052B6325",
+          "poolType": "Virtual",
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.44955,
+        "hops": [
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x62fA288e3AC844dCfcE5469af4f8feb7d6f7Ba61",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "AUDm-CHFm",
+      "tokens": [
+        {
+          "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+          "symbol": "AUDm"
+        },
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x1d013077b00B28038A3f1e7A29ABa34E12e562e9",
+          "token0": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "poolType": "Virtual",
+          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.44955,
+        "hops": [
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x1d013077b00B28038A3f1e7A29ABa34E12e562e9",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "CADm-CHFm",
+      "tokens": [
+        {
+          "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+          "symbol": "CADm"
+        },
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x62fA288e3AC844dCfcE5469af4f8feb7d6f7Ba61",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xff4Ab19391af240c311c54200a492233052B6325",
+          "poolType": "Virtual",
+          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.44955,
+        "hops": [
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x62fA288e3AC844dCfcE5469af4f8feb7d6f7Ba61",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
       "id": "AUDm-ZARm",
       "tokens": [
         {
@@ -3208,50 +4000,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "AUDm-CHFm",
-      "tokens": [
-        {
-          "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-          "symbol": "AUDm"
-        },
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x1d013077b00B28038A3f1e7A29ABa34E12e562e9",
-          "token0": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "poolType": "Virtual",
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.44955,
-        "hops": [
-          {
-            "poolAddress": "0x1d013077b00B28038A3f1e7A29ABa34E12e562e9",
-            "costPercent": 0.15
-          },
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
       "id": "AUDm-PHPm",
       "tokens": [
         {
@@ -3290,50 +4038,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "AUDm-JPYm",
-      "tokens": [
-        {
-          "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-          "symbol": "AUDm"
-        },
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x1d013077b00B28038A3f1e7A29ABa34E12e562e9",
-          "token0": "0x7175504C455076F15c04A2F90a8e352281F492F9",
-          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "poolType": "Virtual",
-          "exchangeId": "0xd580d237231109e6a96d67d82450611c610a805a26660c90281bdc0cd04a95c7"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.44955,
-        "hops": [
-          {
-            "poolAddress": "0x1d013077b00B28038A3f1e7A29ABa34E12e562e9",
-            "costPercent": 0.15
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           }
         ]
@@ -3428,50 +4132,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "CADm-CHFm",
-      "tokens": [
-        {
-          "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-          "symbol": "CADm"
-        },
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x62fA288e3AC844dCfcE5469af4f8feb7d6f7Ba61",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xff4Ab19391af240c311c54200a492233052B6325",
-          "poolType": "Virtual",
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.44955,
-        "hops": [
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x62fA288e3AC844dCfcE5469af4f8feb7d6f7Ba61",
-            "costPercent": 0.15
-          }
-        ]
-      }
-    },
-    {
       "id": "CADm-PHPm",
       "tokens": [
         {
@@ -3510,50 +4170,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CADm-JPYm",
-      "tokens": [
-        {
-          "address": "0xff4Ab19391af240c311c54200a492233052B6325",
-          "symbol": "CADm"
-        },
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x62fA288e3AC844dCfcE5469af4f8feb7d6f7Ba61",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xff4Ab19391af240c311c54200a492233052B6325",
-          "poolType": "Virtual",
-          "exchangeId": "0x517ccc3bcab9f35e2e24143a0c1809068efc649f740846cfb6a1c5703735c1ee"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.44955,
-        "hops": [
-          {
-            "poolAddress": "0x62fA288e3AC844dCfcE5469af4f8feb7d6f7Ba61",
-            "costPercent": 0.15
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           }
         ]
@@ -3721,6 +4337,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "EURm-JPYm",
+      "tokens": [
+        {
+          "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "symbol": "EURm"
+        },
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x1aD2EA06502919F935D9c09028dF73a462979e29",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.54925,
+        "hops": [
+          {
+            "poolAddress": "0x1aD2EA06502919F935D9c09028dF73a462979e29",
+            "costPercent": 0.25
+          },
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-EURm",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "symbol": "EURm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x1aD2EA06502919F935D9c09028dF73a462979e29",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.54925,
+        "hops": [
+          {
+            "poolAddress": "0x1aD2EA06502919F935D9c09028dF73a462979e29",
+            "costPercent": 0.25
+          },
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "EURm-ZARm",
       "tokens": [
         {
@@ -3764,49 +4464,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "CHFm-EURm",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "symbol": "EURm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
-          "poolAddr": "0x1aD2EA06502919F935D9c09028dF73a462979e29",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.54925,
-        "hops": [
-          {
-            "poolAddress": "0x1aD2EA06502919F935D9c09028dF73a462979e29",
-            "costPercent": 0.25
-          },
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
       "id": "EURm-PHPm",
       "tokens": [
         {
@@ -3844,49 +4501,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "EURm-JPYm",
-      "tokens": [
-        {
-          "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "symbol": "EURm"
-        },
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
-          "poolAddr": "0x1aD2EA06502919F935D9c09028dF73a462979e29",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.54925,
-        "hops": [
-          {
-            "poolAddress": "0x1aD2EA06502919F935D9c09028dF73a462979e29",
-            "costPercent": 0.25
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           }
         ]
@@ -3979,6 +4593,90 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "GBPm-JPYm",
+      "tokens": [
+        {
+          "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+          "symbol": "GBPm"
+        },
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x8C0014afe032E4574481D8934504100bF23fCB56",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x8C0014afe032E4574481D8934504100bF23fCB56",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-GBPm",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+          "symbol": "GBPm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x8C0014afe032E4574481D8934504100bF23fCB56",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x8C0014afe032E4574481D8934504100bF23fCB56",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "GBPm-ZARm",
       "tokens": [
         {
@@ -4022,49 +4720,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "CHFm-GBPm",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-          "symbol": "GBPm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
-          "poolAddr": "0x8C0014afe032E4574481D8934504100bF23fCB56",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x8C0014afe032E4574481D8934504100bF23fCB56",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
       "id": "GBPm-PHPm",
       "tokens": [
         {
@@ -4102,49 +4757,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "GBPm-JPYm",
-      "tokens": [
-        {
-          "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-          "symbol": "GBPm"
-        },
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
-          "poolAddr": "0x8C0014afe032E4574481D8934504100bF23fCB56",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x8C0014afe032E4574481D8934504100bF23fCB56",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           }
         ]
@@ -4237,6 +4849,220 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "CHFm-JPYm",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "JPYm-ZARm",
+      "tokens": [
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+          "symbol": "ZARm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x6dAa327E0CbE2CE84c0F312F20b9432Fe744ed58",
+          "token0": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "poolType": "Virtual",
+          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x6dAa327E0CbE2CE84c0F312F20b9432Fe744ed58",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "JPYm-PHPm",
+      "tokens": [
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+          "symbol": "PHPm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
+          "token0": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "poolType": "Virtual",
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "COPm-JPYm",
+      "tokens": [
+        {
+          "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+          "symbol": "COPm"
+        },
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x71f55035a49C972C5C3197e874f6b7Fd94672B6E",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+          "poolType": "Virtual",
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x71f55035a49C972C5C3197e874f6b7Fd94672B6E",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "BRLm-JPYm",
+      "tokens": [
+        {
+          "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+          "symbol": "BRLm"
+        },
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x62753eC2956f84AF240b4666a130C88a83933848",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+          "poolType": "Virtual",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x62753eC2956f84AF240b4666a130C88a83933848",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
       "id": "CHFm-ZARm",
       "tokens": [
         {
@@ -4250,31 +5076,159 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       ],
       "path": [
         {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        },
+        {
           "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
           "poolAddr": "0x6dAa327E0CbE2CE84c0F312F20b9432Fe744ed58",
           "token0": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
           "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
           "poolType": "Virtual",
           "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
         }
       ],
       "costData": {
         "totalCostPercent": 0.5991,
         "hops": [
           {
-            "poolAddress": "0x6dAa327E0CbE2CE84c0F312F20b9432Fe744ed58",
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
             "costPercent": 0.3
           },
           {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
+            "poolAddress": "0x6dAa327E0CbE2CE84c0F312F20b9432Fe744ed58",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-PHPm",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+          "symbol": "PHPm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
+          "token0": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "poolType": "Virtual",
+          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-COPm",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+          "symbol": "COPm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x71f55035a49C972C5C3197e874f6b7Fd94672B6E",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+          "poolType": "Virtual",
+          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x71f55035a49C972C5C3197e874f6b7Fd94672B6E",
+            "costPercent": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "BRLm-CHFm",
+      "tokens": [
+        {
+          "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+          "symbol": "BRLm"
+        },
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x62753eC2956f84AF240b4666a130C88a83933848",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+          "poolType": "Virtual",
+          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.5991,
+        "hops": [
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x62753eC2956f84AF240b4666a130C88a83933848",
             "costPercent": 0.3
           }
         ]
@@ -4319,50 +5273,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-ZARm",
-      "tokens": [
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-          "symbol": "ZARm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x6dAa327E0CbE2CE84c0F312F20b9432Fe744ed58",
-          "token0": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
-          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "poolType": "Virtual",
-          "exchangeId": "0x4206e101b13bf29e40b2bfed4cf167271c41677720f2ee786ac1bf5efac101cb"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x6dAa327E0CbE2CE84c0F312F20b9432Fe744ed58",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           }
         ]
@@ -4457,226 +5367,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "CHFm-PHPm",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
-          "symbol": "PHPm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-          "token0": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
-          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "poolType": "Virtual",
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-JPYm",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-COPm",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
-          "symbol": "COPm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x71f55035a49C972C5C3197e874f6b7Fd94672B6E",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
-          "poolType": "Virtual",
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x71f55035a49C972C5C3197e874f6b7Fd94672B6E",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "BRLm-CHFm",
-      "tokens": [
-        {
-          "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "symbol": "BRLm"
-        },
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x62753eC2956f84AF240b4666a130C88a83933848",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "poolType": "Virtual",
-          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x62753eC2956f84AF240b4666a130C88a83933848",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-PHPm",
-      "tokens": [
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
-          "symbol": "PHPm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-          "token0": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
-          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "poolType": "Virtual",
-          "exchangeId": "0x7952984d7278ca3417febf52815c321984ac3147ced2c02bb6a02b0bcab08413"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
       "id": "COPm-PHPm",
       "tokens": [
         {
@@ -4755,94 +5445,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "hops": [
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x62753eC2956f84AF240b4666a130C88a83933848",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "COPm-JPYm",
-      "tokens": [
-        {
-          "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
-          "symbol": "COPm"
-        },
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x71f55035a49C972C5C3197e874f6b7Fd94672B6E",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
-          "poolType": "Virtual",
-          "exchangeId": "0x1c9378bd0973ff313a599d3effc654ba759f8ccca655ab6d6ce5bd39a212943b"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x71f55035a49C972C5C3197e874f6b7Fd94672B6E",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "BRLm-JPYm",
-      "tokens": [
-        {
-          "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "symbol": "BRLm"
-        },
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x62753eC2956f84AF240b4666a130C88a83933848",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-          "poolType": "Virtual",
-          "exchangeId": "0xd11d52b973ddbb983cc2087aabcafd915fc3140cf9996aacc61db9710d1bde05"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.5991,
-        "hops": [
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           },
           {
@@ -5944,6 +6546,264 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "GHSm-JPYm",
+      "tokens": [
+        {
+          "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+          "symbol": "GHSm"
+        },
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0xab945882018B81bDF62629e98fFdAfd9495a0076",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+          "poolType": "Virtual",
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 1.297,
+        "hops": [
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0xab945882018B81bDF62629e98fFdAfd9495a0076",
+            "costPercent": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "JPYm-NGNm",
+      "tokens": [
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+          "symbol": "NGNm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0xaEa92e8006e6edf0f9E9368Ee9Af36814B738855",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+          "poolType": "Virtual",
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 1.297,
+        "hops": [
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0xaEa92e8006e6edf0f9E9368Ee9Af36814B738855",
+            "costPercent": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "JPYm-KESm",
+      "tokens": [
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+          "symbol": "KESm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0xa337a498e4e061F4029FCb3b9F4E3D535E885dc5",
+          "token0": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "poolType": "Virtual",
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 1.297,
+        "hops": [
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0xa337a498e4e061F4029FCb3b9F4E3D535E885dc5",
+            "costPercent": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-GHSm",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+          "symbol": "GHSm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0xab945882018B81bDF62629e98fFdAfd9495a0076",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+          "poolType": "Virtual",
+          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 1.297,
+        "hops": [
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0xab945882018B81bDF62629e98fFdAfd9495a0076",
+            "costPercent": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-NGNm",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+          "symbol": "NGNm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0xaEa92e8006e6edf0f9E9368Ee9Af36814B738855",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+          "poolType": "Virtual",
+          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 1.297,
+        "hops": [
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0xaEa92e8006e6edf0f9E9368Ee9Af36814B738855",
+            "costPercent": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-KESm",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+          "symbol": "KESm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0xa337a498e4e061F4029FCb3b9F4E3D535E885dc5",
+          "token0": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "poolType": "Virtual",
+          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 1.297,
+        "hops": [
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0xa337a498e4e061F4029FCb3b9F4E3D535E885dc5",
+            "costPercent": 1
+          }
+        ]
+      }
+    },
+    {
       "id": "GHSm-ZARm",
       "tokens": [
         {
@@ -5988,50 +6848,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "CHFm-GHSm",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-          "symbol": "GHSm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xab945882018B81bDF62629e98fFdAfd9495a0076",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-          "poolType": "Virtual",
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 1.297,
-        "hops": [
-          {
-            "poolAddress": "0xab945882018B81bDF62629e98fFdAfd9495a0076",
-            "costPercent": 1
-          },
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
       "id": "GHSm-PHPm",
       "tokens": [
         {
@@ -6070,50 +6886,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "GHSm-JPYm",
-      "tokens": [
-        {
-          "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-          "symbol": "GHSm"
-        },
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xab945882018B81bDF62629e98fFdAfd9495a0076",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
-          "poolType": "Virtual",
-          "exchangeId": "0x3562f9d29eba092b857480a82b03375839c752346b9ebe93a57ab82410328187"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 1.297,
-        "hops": [
-          {
-            "poolAddress": "0xab945882018B81bDF62629e98fFdAfd9495a0076",
-            "costPercent": 1
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           }
         ]
@@ -6296,94 +7068,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "CHFm-NGNm",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-          "symbol": "NGNm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xaEa92e8006e6edf0f9E9368Ee9Af36814B738855",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-          "poolType": "Virtual",
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 1.297,
-        "hops": [
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0xaEa92e8006e6edf0f9E9368Ee9Af36814B738855",
-            "costPercent": 1
-          }
-        ]
-      }
-    },
-    {
-      "id": "CHFm-KESm",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
-          "symbol": "KESm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xa337a498e4e061F4029FCb3b9F4E3D535E885dc5",
-          "token0": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
-          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "poolType": "Virtual",
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 1.297,
-        "hops": [
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0xa337a498e4e061F4029FCb3b9F4E3D535E885dc5",
-            "costPercent": 1
-          }
-        ]
-      }
-    },
-    {
       "id": "NGNm-PHPm",
       "tokens": [
         {
@@ -6422,50 +7106,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-NGNm",
-      "tokens": [
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-          "symbol": "NGNm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xaEa92e8006e6edf0f9E9368Ee9Af36814B738855",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
-          "poolType": "Virtual",
-          "exchangeId": "0x67a5122dab72931be57196e0abba81690461f327bc60fb98ca7eef0ac58906cc"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 1.297,
-        "hops": [
-          {
-            "poolAddress": "0xaEa92e8006e6edf0f9E9368Ee9Af36814B738855",
-            "costPercent": 1
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           }
         ]
@@ -6598,50 +7238,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           },
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-KESm",
-      "tokens": [
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
-          "symbol": "KESm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xa337a498e4e061F4029FCb3b9F4E3D535E885dc5",
-          "token0": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
-          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "poolType": "Virtual",
-          "exchangeId": "0x89de88b8eb790de26f4649f543cb6893d93635c728ac857f0926e842fb0d298b"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 1.297,
-        "hops": [
-          {
-            "poolAddress": "0xa337a498e4e061F4029FCb3b9F4E3D535E885dc5",
-            "costPercent": 1
-          },
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           }
         ]
@@ -7203,6 +7799,92 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "JPYm-XOFm",
+      "tokens": [
+        {
+          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "symbol": "JPYm"
+        },
+        {
+          "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+          "symbol": "XOFm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x3d6e023177Bac13D6E316d95161D4bB9DCf0E276",
+          "token0": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "poolType": "Virtual",
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 2.294,
+        "hops": [
+          {
+            "poolAddress": "0x9861F6D2Fe392b934C86eC89D2886CEb772B2b41",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x3d6e023177Bac13D6E316d95161D4bB9DCf0E276",
+            "costPercent": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "CHFm-XOFm",
+      "tokens": [
+        {
+          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "symbol": "CHFm"
+        },
+        {
+          "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+          "symbol": "XOFm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0xa849b475FE5a4B5C9C3280152c7a1945b907613b",
+          "poolAddr": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
+          "poolAddr": "0x3d6e023177Bac13D6E316d95161D4bB9DCf0E276",
+          "token0": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+          "poolType": "Virtual",
+          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 2.294,
+        "hops": [
+          {
+            "poolAddress": "0xDC81135fD82f02Cae736E261FB676B716663e8b8",
+            "costPercent": 0.3
+          },
+          {
+            "poolAddress": "0x3d6e023177Bac13D6E316d95161D4bB9DCf0E276",
+            "costPercent": 2
+          }
+        ]
+      }
+    },
+    {
       "id": "XOFm-ZARm",
       "tokens": [
         {
@@ -7247,50 +7929,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "CHFm-XOFm",
-      "tokens": [
-        {
-          "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "symbol": "CHFm"
-        },
-        {
-          "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-          "symbol": "XOFm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
-          "poolType": "Virtual",
-          "exchangeId": "0x3ddbc61433314a4b7d3cbb56a001fc4cc0f1d52d64338336d5f2083a580ce4fc"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x3d6e023177Bac13D6E316d95161D4bB9DCf0E276",
-          "token0": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "poolType": "Virtual",
-          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 2.294,
-        "hops": [
-          {
-            "poolAddress": "0xbe6d2165173A29889652c7bF2Dc3a02076a22f2A",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x3d6e023177Bac13D6E316d95161D4bB9DCf0E276",
-            "costPercent": 2
-          }
-        ]
-      }
-    },
-    {
       "id": "PHPm-XOFm",
       "tokens": [
         {
@@ -7325,50 +7963,6 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         "hops": [
           {
             "poolAddress": "0x30214Efe28Ab44D6A5c739ebA5e0729B1d4213E4",
-            "costPercent": 0.3
-          },
-          {
-            "poolAddress": "0x3d6e023177Bac13D6E316d95161D4bB9DCf0E276",
-            "costPercent": 2
-          }
-        ]
-      }
-    },
-    {
-      "id": "JPYm-XOFm",
-      "tokens": [
-        {
-          "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "symbol": "JPYm"
-        },
-        {
-          "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-          "symbol": "XOFm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
-          "token0": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "token1": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
-          "poolType": "Virtual",
-          "exchangeId": "0x7c3b41fbd140c6fb54ff9f8f7b7b0c954606682d44ed5e56b0080f40faaf652c"
-        },
-        {
-          "factoryAddr": "0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3",
-          "poolAddr": "0x3d6e023177Bac13D6E316d95161D4bB9DCf0E276",
-          "token0": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-          "token1": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-          "poolType": "Virtual",
-          "exchangeId": "0xc9664df358594c5eaf2f410ab371e2deb8b532ca26162d2bc36d99b8d174567b"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 2.294,
-        "hops": [
-          {
-            "poolAddress": "0xEB433cE1f2ce4981b76fE7ca3a96070705D8eDe4",
             "costPercent": 0.3
           },
           {

--- a/src/cache/tokens.ts
+++ b/src/cache/tokens.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on 2026-04-23T15:34:16.106Z
+// Generated on 2026-04-27T16:44:41.707Z
 
 import type { Token } from '../core/types'
 
@@ -71,6 +71,18 @@ export const cachedTokens: Record<number, readonly Token[]> = {
       symbol: TokenSymbol.EURm,
       name: 'Mento Euro',
       decimals: 18,
+    },
+    {
+      address: '0x22f6A6752800eAB67b84748FeFc3cC658384aF72',
+      symbol: TokenSymbol.JPYm,
+      name: 'Mento Japanese Yen',
+      decimals: 18,
+    },
+    {
+      address: '0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C',
+      symbol: TokenSymbol.CHFm,
+      name: 'Mento Swiss Franc',
+      decimals: 18,
     }
   ],
   // Chain 10143
@@ -109,6 +121,18 @@ export const cachedTokens: Record<number, readonly Token[]> = {
       address: '0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0',
       symbol: TokenSymbol.EURm,
       name: 'Mento Euro',
+      decimals: 18,
+    },
+    {
+      address: '0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1',
+      symbol: TokenSymbol.JPYm,
+      name: 'Mento Japanese Yen',
+      decimals: 18,
+    },
+    {
+      address: '0xCD8f6950359795eb4688AC18d1e9BB88fa111eEe',
+      symbol: TokenSymbol.CHFm,
+      name: 'Mento Swiss Franc',
       decimals: 18,
     }
   ],
@@ -157,6 +181,18 @@ export const cachedTokens: Record<number, readonly Token[]> = {
       decimals: 6,
     },
     {
+      address: '0xc45eCF20f3CD864B32D9794d6f76814aE8892e20',
+      symbol: TokenSymbol.JPYm,
+      name: 'Mento Japanese Yen',
+      decimals: 18,
+    },
+    {
+      address: '0xb55a79F398E759E43C95b979163f30eC87Ee131D',
+      symbol: TokenSymbol.CHFm,
+      name: 'Mento Swiss Franc',
+      decimals: 18,
+    },
+    {
       address: '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
       symbol: TokenSymbol.GHSm,
       name: 'Mento Ghanaian Cedi',
@@ -172,12 +208,6 @@ export const cachedTokens: Record<number, readonly Token[]> = {
       address: '0x7175504C455076F15c04A2F90a8e352281F492F9',
       symbol: TokenSymbol.AUDm,
       name: 'Mento Australian Dollar',
-      decimals: 18,
-    },
-    {
-      address: '0xb55a79F398E759E43C95b979163f30eC87Ee131D',
-      symbol: TokenSymbol.CHFm,
-      name: 'Mento Swiss Franc',
       decimals: 18,
     },
     {
@@ -202,12 +232,6 @@ export const cachedTokens: Record<number, readonly Token[]> = {
       address: '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
       symbol: TokenSymbol.PHPm,
       name: 'Mento Philippine Peso',
-      decimals: 18,
-    },
-    {
-      address: '0xc45eCF20f3CD864B32D9794d6f76814aE8892e20',
-      symbol: TokenSymbol.JPYm,
-      name: 'Mento Japanese Yen',
       decimals: 18,
     },
     {
@@ -362,6 +386,8 @@ export const TOKEN_ADDRESSES_BY_CHAIN: {
     [TokenSymbol.AUSD]: '0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a',
     [TokenSymbol.USDT0]: '0xe7cd86e13AC4309349F30B3435a9d337750fC82D',
     [TokenSymbol.EURm]: '0x4D502d735B4C574B487Ed641ae87cEaE884731C7',
+    [TokenSymbol.JPYm]: '0x22f6A6752800eAB67b84748FeFc3cC658384aF72',
+    [TokenSymbol.CHFm]: '0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C',
   },
   10143: {
     [TokenSymbol.GBPm]: '0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9',
@@ -370,6 +396,8 @@ export const TOKEN_ADDRESSES_BY_CHAIN: {
     [TokenSymbol.AUSD]: '0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B',
     [TokenSymbol.USDT0]: '0xC304EE1876c32d1A194558B1000bE4842F960dF9',
     [TokenSymbol.EURm]: '0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0',
+    [TokenSymbol.JPYm]: '0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1',
+    [TokenSymbol.CHFm]: '0xCD8f6950359795eb4688AC18d1e9BB88fa111eEe',
   },
   42220: {
     [TokenSymbol.GBPm]: '0xCCF663b1fF11028f0b19058d0f7B674004a40746',
@@ -379,15 +407,15 @@ export const TOKEN_ADDRESSES_BY_CHAIN: {
     [TokenSymbol.USD_]: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
     [TokenSymbol.EURm]: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
     [TokenSymbol.axlEUROC]: '0x061cc5a2C863E0C1Cb404006D559dB18A34C762d',
+    [TokenSymbol.JPYm]: '0xc45eCF20f3CD864B32D9794d6f76814aE8892e20',
+    [TokenSymbol.CHFm]: '0xb55a79F398E759E43C95b979163f30eC87Ee131D',
     [TokenSymbol.GHSm]: '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313',
     [TokenSymbol.ZARm]: '0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6',
     [TokenSymbol.AUDm]: '0x7175504C455076F15c04A2F90a8e352281F492F9',
-    [TokenSymbol.CHFm]: '0xb55a79F398E759E43C95b979163f30eC87Ee131D',
     [TokenSymbol.NGNm]: '0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71',
     [TokenSymbol.KESm]: '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0',
     [TokenSymbol.CADm]: '0xff4Ab19391af240c311c54200a492233052B6325',
     [TokenSymbol.PHPm]: '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B',
-    [TokenSymbol.JPYm]: '0xc45eCF20f3CD864B32D9794d6f76814aE8892e20',
     [TokenSymbol.COPm]: '0x8A567e2aE79CA692Bd748aB832081C45de4041eA',
     [TokenSymbol.BRLm]: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
     [TokenSymbol.XOFm]: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08',

--- a/src/cache/tokens.ts
+++ b/src/cache/tokens.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on 2026-04-16T14:26:59.057Z
+// Generated on 2026-04-23T15:34:16.106Z
 
 import type { Token } from '../core/types'
 
@@ -274,6 +274,18 @@ export const cachedTokens: Record<number, readonly Token[]> = {
       decimals: 18,
     },
     {
+      address: '0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426',
+      symbol: TokenSymbol.JPYm,
+      name: 'Mento Japanese Yen',
+      decimals: 18,
+    },
+    {
+      address: '0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980',
+      symbol: TokenSymbol.CHFm,
+      name: 'Mento Swiss Franc',
+      decimals: 18,
+    },
+    {
       address: '0x0352976d940a2C3FBa0C3623198947Ee1d17869E',
       symbol: TokenSymbol.PHPm,
       name: 'Mento Philippine Peso',
@@ -301,18 +313,6 @@ export const cachedTokens: Record<number, readonly Token[]> = {
       address: '0x10CCfB235b0E1Ed394bACE4560C3ed016697687e',
       symbol: TokenSymbol.ZARm,
       name: 'Mento South African Rand',
-      decimals: 18,
-    },
-    {
-      address: '0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980',
-      symbol: TokenSymbol.CHFm,
-      name: 'Mento Swiss Franc',
-      decimals: 18,
-    },
-    {
-      address: '0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426',
-      symbol: TokenSymbol.JPYm,
-      name: 'Mento Japanese Yen',
       decimals: 18,
     },
     {
@@ -400,13 +400,13 @@ export const TOKEN_ADDRESSES_BY_CHAIN: {
     [TokenSymbol.USD_]: '0xd077A400968890Eacc75cdc901F0356c943e4fDb',
     [TokenSymbol.EURm]: '0xA99dC247d6b7B2E3ab48a1fEE101b83cD6aCd82a',
     [TokenSymbol.axlEUROC]: '0x9883d788d40F1C7595a780ed881Ea833C7743B4B',
+    [TokenSymbol.JPYm]: '0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426',
+    [TokenSymbol.CHFm]: '0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980',
     [TokenSymbol.PHPm]: '0x0352976d940a2C3FBa0C3623198947Ee1d17869E',
     [TokenSymbol.XOFm]: '0x5505b70207aE3B826c1A7607F19F3Bf73444A082',
     [TokenSymbol.AUDm]: '0x5873Faeb42F3563dcD77F0fbbdA818E6d6DA3139',
     [TokenSymbol.CADm]: '0xF151c9a13b78C84f93f50B8b3bC689fedc134F60',
     [TokenSymbol.ZARm]: '0x10CCfB235b0E1Ed394bACE4560C3ed016697687e',
-    [TokenSymbol.CHFm]: '0x284E9b7B623eAE866914b7FA0eB720C2Bb3C2980',
-    [TokenSymbol.JPYm]: '0x85Bee67D435A39f7467a8a9DE34a5B73D25Df426',
     [TokenSymbol.COPm]: '0x5F8d55c3627d2dc0a2B4afa798f877242F382F67',
     [TokenSymbol.BRLm]: '0x2294298942fdc79417DE9E0D740A4957E0e7783a',
     [TokenSymbol.GHSm]: '0x5e94B8C872bD47BC4255E60ECBF44D5E66e7401C',

--- a/src/core/constants/borrowRegistries.ts
+++ b/src/core/constants/borrowRegistries.ts
@@ -7,12 +7,13 @@ import { ChainId } from './chainId'
 export const borrowRegistries: Record<number, Record<string, string>> = {
   [ChainId.CELO]: {
     GBPm: '0xB3136DBadB14Ab587FFa91545538126938Fe0C6E',
-    // TODO(@nvtaveras): Add the mapping from the token symbol to address registry on CELO here, just like Sepolia
+    CHFm: '0xCa70801D91576d069190d1D4CFDDEbdc237A4537',
+    JPYm: '0x8f99Aac2FE09A1390617D4AcDD1519f775eE931A',
   },
   [ChainId.CELO_SEPOLIA]: {
     GBPm: '0x8b33D626E8d79388889d404fBC515Ed131c9508e',
     CHFm: '0x1e3CCCC62cEBd9Bf2a26Ba512E3abee086816c58',
-    JPYm: '0x812e5ccec5e55b81f4270898fdf1c916e3a284fb',
+    JPYm: '0x812e5ccEC5E55B81F4270898FDF1C916e3a284Fb',
   },
 }
 

--- a/src/core/constants/borrowRegistries.ts
+++ b/src/core/constants/borrowRegistries.ts
@@ -7,6 +7,7 @@ import { ChainId } from './chainId'
 export const borrowRegistries: Record<number, Record<string, string>> = {
   [ChainId.CELO]: {
     GBPm: '0xB3136DBadB14Ab587FFa91545538126938Fe0C6E',
+    // TODO(@nvtaveras): Add the mapping from the token symbol to address registry on CELO here, just like Sepolia
   },
   [ChainId.CELO_SEPOLIA]: {
     GBPm: '0x8b33D626E8d79388889d404fBC515Ed131c9508e',

--- a/src/core/constants/borrowRegistries.ts
+++ b/src/core/constants/borrowRegistries.ts
@@ -10,6 +10,8 @@ export const borrowRegistries: Record<number, Record<string, string>> = {
   },
   [ChainId.CELO_SEPOLIA]: {
     GBPm: '0x8b33D626E8d79388889d404fBC515Ed131c9508e',
+    CHFm: '0x1e3CCCC62cEBd9Bf2a26Ba512E3abee086816c58',
+    JPYm: '0x812e5ccec5e55b81f4270898fdf1c916e3a284fb',
   },
 }
 


### PR DESCRIPTION
### Description

Updates to support the new deployments of CHFm & JPYm. 

- Regenerate token & route caches
- Adds new address registries to borrow registries mapping

### Other changes

- Bumped package version

### Tested

- Tested in the UI locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the npm package version with no functional code changes.
> 
> **Overview**
> Bumps `@mento-protocol/mento-sdk` package version from `3.2.5` to `3.2.6` in `package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9886810f1fd99459557b2f6d339e2176ec022543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->