### PR TITLE
chore: allowlist install scripts for esbuild and unrs-resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,11 @@
   },
   "dependencies": {
     "viem": "^2.21.44"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "unrs-resolver"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `pnpm.onlyBuiltDependencies` allowlist to [package.json](package.json) for `esbuild` and `unrs-resolver`
- Unblocks the gh-actions group bump in #165

## Why

PR #165 bumps `pnpm/action-setup` to v6, which ships pnpm 11 internals. pnpm 10+ no longer silently ignores unapproved postinstall scripts — it surfaces `ERR_PNPM_IGNORED_BUILDS` as a hard error during install. The Node 20.x job in #165 fails for that exact reason:

```
ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild@0.27.4, unrs-resolver@1.11.1
##[error]Process completed with exit code 1.
```

Explicitly allowlisting these is also a security-positive move — it makes the set of trusted-to-execute install scripts auditable in version control rather than relying on default permissive behavior.

## Why these two are safe to allowlist

| Package | Comes from | Postinstall purpose |
| --- | --- | --- |
| `esbuild@0.27.4` | `@size-limit/preset-small-lib` (dev) | Native binary extraction |
| `unrs-resolver@1.11.1` | `jest-resolve` via `jest@30` (dev) | Fetches Rust native module via `napi-postinstall` |

Both are dev-only transitives from established, widely-used packages.

## Test plan

- [x] `pnpm install --frozen-lockfile` clean under pnpm 9.15
- [x] `pnpm install --frozen-lockfile` clean under pnpm 10.33 (matches what #165 will trigger)
- [x] No lockfile change required (only `package.json`)
- [ ] CI green here, then rebase #165 to confirm it unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change that only affects dependency install/build-script behavior, with no runtime code or API modifications.
> 
> **Overview**
> Adds `pnpm.onlyBuiltDependencies` to `package.json` to explicitly allow pnpm to run install/build scripts for `esbuild` and `unrs-resolver`, preventing `ERR_PNPM_IGNORED_BUILDS` failures on newer pnpm versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2210a49d8f1cdb2b1c70cf5950d378d2e28956b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->