### PR TITLE
fix(zapIn): re-quote min amounts against post-swap reserves

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "3.2.6",
+  "version": "3.2.7-beta.0",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "3.2.7-beta.0",
+  "version": "3.2.7",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/src/services/liquidity/zapHelpers.ts
+++ b/src/services/liquidity/zapHelpers.ts
@@ -125,6 +125,83 @@ export function splitAmount(amountIn: bigint, splitRatio: number): { amountA: bi
 }
 
 /**
+ * Off-chain mirror of Router.sol's quoteAddLiquidity / _quoteZapLiquidity logic.
+ *
+ * Given desired amounts and pool reserves, returns the (amountA, amountB) the
+ * router will actually deposit when adding liquidity. Used to predict the exact
+ * `amountAMin` / `amountBMin` the contract will check against post-swap reserves.
+ *
+ * @param amountADesired - Desired amount of tokenA
+ * @param amountBDesired - Desired amount of tokenB
+ * @param reserveA - Reserve of tokenA at the moment liquidity is added
+ * @param reserveB - Reserve of tokenB at the moment liquidity is added
+ */
+export function quoteAddLiquidityFromReserves(
+  amountADesired: bigint,
+  amountBDesired: bigint,
+  reserveA: bigint,
+  reserveB: bigint
+): { amountA: bigint; amountB: bigint } {
+  if (reserveA === 0n && reserveB === 0n) {
+    return { amountA: amountADesired, amountB: amountBDesired }
+  }
+  if (reserveA === 0n || reserveB === 0n) {
+    // Mirrors Router.sol's InsufficientLiquidity revert. Caller can fall back.
+    return { amountA: 0n, amountB: 0n }
+  }
+
+  const amountBOptimal = (amountADesired * reserveB) / reserveA
+  if (amountBOptimal <= amountBDesired) {
+    return { amountA: amountADesired, amountB: amountBOptimal }
+  }
+  const amountAOptimal = (amountBDesired * reserveA) / reserveB
+  return { amountA: amountAOptimal, amountB: amountBDesired }
+}
+
+/**
+ * Computes the net delta a single-hop zap swap applies to a target pool's
+ * reserves. Returns `{delta0, delta1}` to add to the pool's pre-swap reserves
+ * to obtain the reserves the router will see when it runs `_quoteZapLiquidity`.
+ *
+ * Only single-hop routes whose factory matches the target pool's factory and
+ * whose `(from, to)` are `(token0, token1)` (in either direction) are
+ * considered. Multi-hop routes and routes through other pools have no effect
+ * on the target pool's reserves and return `{0, 0}`.
+ *
+ * Note: Multi-hop routes that traverse the target pool as an intermediate hop
+ * are intentionally not handled here — they are uncommon for single-sided zaps
+ * and would require per-hop amounts from `getAmountsOut`.
+ */
+export function computeTargetPoolImpact(
+  routes: RouterRoute[],
+  amountIn: bigint,
+  amountOut: bigint,
+  token0: Address,
+  token1: Address,
+  factoryAddr: Address
+): { delta0: bigint; delta1: bigint } {
+  if (routes.length !== 1) {
+    return { delta0: 0n, delta1: 0n }
+  }
+  const route = routes[0]
+  if (route.factory.toLowerCase() !== factoryAddr.toLowerCase()) {
+    return { delta0: 0n, delta1: 0n }
+  }
+  const fromLower = route.from.toLowerCase()
+  const toLower = route.to.toLowerCase()
+  const t0 = token0.toLowerCase()
+  const t1 = token1.toLowerCase()
+
+  if (fromLower === t0 && toLower === t1) {
+    return { delta0: amountIn, delta1: -amountOut }
+  }
+  if (fromLower === t1 && toLower === t0) {
+    return { delta0: -amountOut, delta1: amountIn }
+  }
+  return { delta0: 0n, delta1: 0n }
+}
+
+/**
  * Estimates minimum LP tokens from zap in amounts.
  *
  * This is a conservative lower-bound estimate. The inputs are slippage-adjusted

--- a/src/services/liquidity/zapIn.ts
+++ b/src/services/liquidity/zapIn.ts
@@ -19,6 +19,8 @@ import {
   findZapInRoutes,
   splitAmount,
   estimateLiquidityFromZapIn,
+  quoteAddLiquidityFromReserves,
+  computeTargetPoolImpact,
 } from './zapHelpers'
 
 interface ZapInPreparedContext {
@@ -208,8 +210,28 @@ async function prepareZapInContextInternal(
     args: [token0, token1, factoryAddr, amountInA, amountInB, routesA as ReadonlyRouterRoutes, routesB as ReadonlyRouterRoutes],
   })) as [bigint, bigint, bigint, bigint]
 
-  const finalAmountAMin = calculateMinAmount(amountAMin, options.slippageTolerance)
-  const finalAmountBMin = calculateMinAmount(amountBMin, options.slippageTolerance)
+  // Re-quote amountAMin / amountBMin against POST-swap reserves.
+  //
+  // `generateZapInParams` calls `quoteAddLiquidity` with the pool's *current*
+  // reserves, but on-chain `_quoteZapLiquidity` runs *after* the zap's internal
+  // swap, which moves the same pool when tokenIn is one of the pool tokens.
+  // Applying user slippage on top of a pre-swap minimum makes the contract
+  // reject any non-trivial amount because the deterministic price impact of
+  // the swap alone exceeds the slippage budget. Predict the post-swap reserves
+  // and re-derive the minimums so that user slippage only covers real drift
+  // between quote-time and execution.
+  const impactA = computeTargetPoolImpact(routesA, amountInA, amountOutMinA, token0, token1, factoryAddr)
+  const impactB = computeTargetPoolImpact(routesB, amountInB, amountOutMinB, token0, token1, factoryAddr)
+  const projectedReserveA = poolSnapshot.reserve0 + impactA.delta0 + impactB.delta0
+  const projectedReserveB = poolSnapshot.reserve1 + impactA.delta1 + impactB.delta1
+  const useReserveA = projectedReserveA > 0n ? projectedReserveA : poolSnapshot.reserve0
+  const useReserveB = projectedReserveB > 0n ? projectedReserveB : poolSnapshot.reserve1
+  const projected = quoteAddLiquidityFromReserves(amountOutMinA, amountOutMinB, useReserveA, useReserveB)
+  const baselineAmountAMin = projected.amountA > 0n ? projected.amountA : amountAMin
+  const baselineAmountBMin = projected.amountB > 0n ? projected.amountB : amountBMin
+
+  const finalAmountAMin = calculateMinAmount(baselineAmountAMin, options.slippageTolerance)
+  const finalAmountBMin = calculateMinAmount(baselineAmountBMin, options.slippageTolerance)
   const finalAmountOutMinA = calculateMinAmount(amountOutMinA, options.slippageTolerance)
   const finalAmountOutMinB = calculateMinAmount(amountOutMinB, options.slippageTolerance)
 


### PR DESCRIPTION
## Summary

Fixes a bug where any non-trivial single-sided zap-in reverts on-chain with `InsufficientAmountB` / `InsufficientAmountA`, regardless of how high the user widens slippage. At 1% slippage the cap was ~2% of pool reserves; larger amounts always failed.

### Root cause

`Router.generateZapInParams` runs `quoteAddLiquidity` against the pool's **pre-swap** reserves to derive `amountAMin` / `amountBMin`. The on-chain `_quoteZapLiquidity` runs **after** the zap's internal swap, which moves the same pool when `tokenIn` is one of the pool's tokens (the common single-sided case).

When the SDK applies user slippage on top of a pre-swap minimum, the deterministic price impact of the swap alone consumes the entire slippage budget, leaving none for actual quote-vs-execution drift. The contract sees a `amountBOptimal` calculated against the moved reserves and a `amountBMin` calibrated to the unmoved reserves, and reverts.

Math: with input `a` split 50/50 and pre-swap reserves `(Rx, Ry)`, the contract's post-swap `amountBOptimal` is `Rx / (Rx + a/2)` of the SDK's pre-swap `amountBMin`. To not revert, user slippage `s` must satisfy `a ≤ (2s / (1 − s)) · Rx`. At `s = 0.01` that's ~2% of the pool.

### Fix

After `generateZapInParams`, project the post-swap reserves of the target pool from the zap swap deltas, then re-derive `amountAMin` / `amountBMin` against those projected reserves before applying user slippage. User slippage now only buffers actual drift between quote-time and execution, not the deterministic swap impact.

Two new helpers in `zapHelpers.ts`:

- `quoteAddLiquidityFromReserves(amountADesired, amountBDesired, reserveA, reserveB)` — off-chain mirror of `Router.quoteAddLiquidity` / `_quoteZapLiquidity`.
- `computeTargetPoolImpact(routes, amountIn, amountOut, token0, token1, factoryAddr)` — returns `{delta0, delta1}` to add to the target pool's reserves when a zap swap traverses it.

Scope: handles the common single-hop case (single-sided zap where `tokenIn ∈ {token0, token1}` and the route's only hop is on the target pool). Routes through unrelated pools or multi-hop routes return zero impact and fall back to the existing behavior, which is correct for those cases.

Note: `zapOut` has a structurally similar issue (`generateZapOutParams` computes minimums against pre-burn reserves, but the swap runs after the burn). Out of scope here — left as a follow-up.

### Verification

- 446 / 446 unit tests pass.
- Verified end-to-end against `app.mento.org` running this SDK as `3.2.7-beta.0` — single-sided zaps that previously reverted at any reasonable amount now succeed at 1% slippage.

## Test plan

- [ ] CI green
- [ ] Manual: single-sided zap-in with `tokenIn == token0` at varied amounts (1%, 5%, 25% of pool reserves) at 0.5% / 1% / 5% slippage
- [ ] Manual: single-sided zap-in with `tokenIn == token1` (mirror case)
- [ ] Manual: zap-in with `tokenIn` outside the pool (route through other pools) — should remain unchanged
- [ ] Manual: confirm small amounts that already worked still work (no regression on the easy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 088791d86887ea2af2126842fb3930feb5dc2154. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->