### PR TITLE
feat: add support for Base Sepolia

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "3.3.0-beta.0",
+  "version": "3.3.0-beta.1",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/scripts/shared/network.ts
+++ b/scripts/shared/network.ts
@@ -5,6 +5,7 @@ export const NETWORK_MAP: Record<string, number> = {
   monad: 143,
   ['monad-testnet']: 10143,
   ['polygon-amoy']: 80002,
+  ['base-sepolia']: 84532,
 }
 
 // RPC URLs for different networks
@@ -15,6 +16,7 @@ export const rpcUrls = {
   143: process.env.MONAD_RPC_URL || 'https://rpc.monad.xyz',
   10143: process.env.MONAD_TESTNET_RPC_URL || 'https://testnet-rpc.monad.xyz',
   80002: process.env.POLYGON_AMOY_RPC_URL || 'https://polygon-amoy.drpc.org',
+  84532: process.env.BASE_SEPOLIA_RPC_URL || 'https://base-sepolia.drpc.org',
 } as const
 
 // Type for supported chain IDs
@@ -32,21 +34,14 @@ export interface NetworkConfig {
  * @param chainIdArg - The chainId argument (e.g., '42220', '11142220')
  * @returns NetworkConfig with chainId and rpcUrl
  */
-export function parseNetworkArgs(
-  networkArg?: string,
-  chainIdArg?: string
-): NetworkConfig {
+export function parseNetworkArgs(networkArg?: string, chainIdArg?: string): NetworkConfig {
   let chainId: number
   let rpcUrl: string
 
   if (networkArg) {
     const networkName = networkArg.toLowerCase()
     if (!NETWORK_MAP[networkName]) {
-      console.error(
-        `Invalid network "${networkArg}". Valid networks: ${Object.keys(
-          NETWORK_MAP
-        ).join(', ')}`
-      )
+      console.error(`Invalid network "${networkArg}". Valid networks: ${Object.keys(NETWORK_MAP).join(', ')}`)
       process.exit(1)
     }
     chainId = NETWORK_MAP[networkName]
@@ -54,11 +49,7 @@ export function parseNetworkArgs(
   } else if (chainIdArg) {
     chainId = Number(chainIdArg)
     if (!rpcUrls[chainId as keyof typeof rpcUrls]) {
-      console.error(
-        `Invalid chainId "${chainId}". Valid chainIds: ${Object.keys(
-          rpcUrls
-        ).join(', ')}`
-      )
+      console.error(`Invalid chainId "${chainId}". Valid chainIds: ${Object.keys(rpcUrls).join(', ')}`)
       process.exit(1)
     }
     rpcUrl = rpcUrls[chainId as keyof typeof rpcUrls]
@@ -77,8 +68,6 @@ export function parseNetworkArgs(
  * @returns The network name or 'Unknown' if not found
  */
 export function getNetworkName(chainId: number): string {
-  const networkEntry = Object.entries(NETWORK_MAP).find(
-    ([, id]) => id === chainId
-  )
+  const networkEntry = Object.entries(NETWORK_MAP).find(([, id]) => id === chainId)
   return networkEntry ? networkEntry[0] : 'Unknown'
 }

--- a/src/cache/routes.ts
+++ b/src/cache/routes.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on 2026-04-30T16:05:05.474Z
+// Generated on 2026-05-06T12:40:03.576Z
 
 import type { RouteWithCost } from '../core/types'
 
@@ -1206,6 +1206,48 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
+      "id": "AUSD-USDT0",
+      "tokens": [
+        {
+          "address": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
+          "symbol": "AUSD"
+        },
+        {
+          "address": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
+          "symbol": "USDT0"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
+          "token0": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.099975,
+        "hops": [
+          {
+            "poolAddress": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
+            "costPercent": 0.05
+          }
+        ]
+      }
+    },
+    {
       "id": "GBPm-USDm",
       "tokens": [
         {
@@ -1414,15 +1456,99 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
       }
     },
     {
-      "id": "AUSD-JPYm",
+      "id": "GBPm-USDT0",
+      "tokens": [
+        {
+          "address": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
+          "symbol": "GBPm"
+        },
+        {
+          "address": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
+          "symbol": "USDT0"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+          "token0": "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.199925,
+        "hops": [
+          {
+            "poolAddress": "0x550D9EcB4C373510b8A41f5fB7D98E9E1c51A07e",
+            "costPercent": 0.15
+          },
+          {
+            "poolAddress": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
+            "costPercent": 0.05
+          }
+        ]
+      }
+    },
+    {
+      "id": "AUSD-EURm",
       "tokens": [
         {
           "address": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
           "symbol": "AUSD"
         },
         {
+          "address": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "symbol": "EURm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
+          "token0": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
+          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.199925,
+        "hops": [
+          {
+            "poolAddress": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+            "costPercent": 0.15
+          }
+        ]
+      }
+    },
+    {
+      "id": "JPYm-USDT0",
+      "tokens": [
+        {
           "address": "0x377755da4994c2cfE21b39bbCE7211eab6f5FCC1",
           "symbol": "JPYm"
+        },
+        {
+          "address": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
+          "symbol": "USDT0"
         }
       ],
       "path": [
@@ -1435,9 +1561,9 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
         },
         {
           "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
-          "token0": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
-          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "poolAddr": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0xC304EE1876c32d1A194558B1000bE4842F960dF9",
           "poolType": "FPMM"
         }
       ],
@@ -1449,50 +1575,8 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
             "costPercent": 0.15
           },
           {
-            "poolAddress": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
+            "poolAddress": "0xa51a83F0260a83A7F9AdFecC1Bc93C58DEf2c9A2",
             "costPercent": 0.05
-          }
-        ]
-      }
-    },
-    {
-      "id": "AUSD-CHFm",
-      "tokens": [
-        {
-          "address": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
-          "symbol": "AUSD"
-        },
-        {
-          "address": "0xCD8f6950359795eb4688AC18d1e9BB88fa111eEe",
-          "symbol": "CHFm"
-        }
-      ],
-      "path": [
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
-          "token0": "0x502E67D3fE9302A5e4Ec1CFCDdbD6F34F9B9484B",
-          "token1": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "poolType": "FPMM"
-        },
-        {
-          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
-          "poolAddr": "0x49e220DB6255061E0A49e679A115A4e6948971Ce",
-          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
-          "token1": "0xCD8f6950359795eb4688AC18d1e9BB88fa111eEe",
-          "poolType": "FPMM"
-        }
-      ],
-      "costData": {
-        "totalCostPercent": 0.199925,
-        "hops": [
-          {
-            "poolAddress": "0x52716E8F44E417bE8F573F8A85cA8eD3DAe1eAE1",
-            "costPercent": 0.05
-          },
-          {
-            "poolAddress": "0x49e220DB6255061E0A49e679A115A4e6948971Ce",
-            "costPercent": 0.15
           }
         ]
       }
@@ -8085,6 +8169,40 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           {
             "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
             "costPercent": 0.05
+          }
+        ]
+      }
+    }
+  ],
+  // Chain 84532
+  84532: [
+    {
+      "id": "EURC-EURm",
+      "tokens": [
+        {
+          "address": "0xe36C65cF840C16F45A0bd89628B89a9414DFda82",
+          "symbol": "EURC"
+        },
+        {
+          "address": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "symbol": "EURm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xAe025fa0F87b40b0d22A3CAf136a5224A09149C3",
+          "token0": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "token1": "0xe36C65cF840C16F45A0bd89628B89a9414DFda82",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.4,
+        "hops": [
+          {
+            "poolAddress": "0xAe025fa0F87b40b0d22A3CAf136a5224A09149C3",
+            "costPercent": 0.4
           }
         ]
       }

--- a/src/cache/tokens.ts
+++ b/src/cache/tokens.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on 2026-04-30T16:03:41.719Z
+// Generated on 2026-05-06T12:39:32.137Z
 
 import type { Token } from '../core/types'
 
@@ -13,6 +13,7 @@ export enum TokenSymbol {
   CADm = 'CADm',
   CHFm = 'CHFm',
   COPm = 'COPm',
+  EURC = 'EURC',
   EURm = 'EURm',
   GBPm = 'GBPm',
   GHSm = 'GHSm',
@@ -274,6 +275,21 @@ export const cachedTokens: Record<number, readonly Token[]> = {
       decimals: 18,
     }
   ],
+  // Chain 84532
+  84532: [
+    {
+      address: '0xe36C65cF840C16F45A0bd89628B89a9414DFda82',
+      symbol: TokenSymbol.EURC,
+      name: 'Mento Mock EURC',
+      decimals: 6,
+    },
+    {
+      address: '0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0',
+      symbol: TokenSymbol.EURm,
+      name: 'Mento Euro',
+      decimals: 18,
+    }
+  ],
   // Chain 11142220
   11142220: [
     {
@@ -444,6 +460,10 @@ export const TOKEN_ADDRESSES_BY_CHAIN: {
   80002: {
     [TokenSymbol.USDC]: '0xfbD2d6a7C3Cb4491647173D6eCb2a4473521cd66',
     [TokenSymbol.USDm]: '0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc',
+    [TokenSymbol.EURm]: '0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0',
+  },
+  84532: {
+    [TokenSymbol.EURC]: '0xe36C65cF840C16F45A0bd89628B89a9414DFda82',
     [TokenSymbol.EURm]: '0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0',
   },
   11142220: {

--- a/src/core/constants/addresses.ts
+++ b/src/core/constants/addresses.ts
@@ -75,6 +75,18 @@ export const addresses: ContractAddressMap = {
     OpenLiquidityStrategy: '0xCCd2aD0603a08EBc14D223a983171ef18192e8c9',
   },
 
+  [ChainId.BASE_SEPOLIA]: {
+    BreakerBox: '0x88869E30609D2C0E4032463D713328C6f541878e',
+    MedianDeltaBreaker: '0xf923C884F319b8866F67C5719A80E5cB4D0FAF2c',
+    SortedOracles: '0x85ed9ac57827132B8F60938F3165BC139E1F53cd',
+    ValueDeltaBreaker: '0xbbD0D093F5F11D16D4456FBd6229c9a3b70B8Aaf',
+    Reserve: '0xbCdc1D0b92DfceEaa0FcD0a0D53355F4bF1DB8a7',
+    StableToken: '0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0', // EURm
+    FPMMFactory: '0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980',
+    Router: '0xcf6cD45210b3ffE3cA28379C4683F1e60D0C2CCd',
+    ReserveLiquidityStrategy: '0x734bb3251Ec3f1A83f8f2A8609bcEF649D54EbF8',
+  },
+
   [ChainId.CELO_SEPOLIA]: {
     // Oracles & Breakers
     BreakerBox: '0x578bD46003B9D3fd4c3C3f47c98B329562a6a1dE',

--- a/src/core/constants/chainId.ts
+++ b/src/core/constants/chainId.ts
@@ -4,4 +4,5 @@ export enum ChainId {
   MONAD_TESTNET = 10143,
   MONAD = 143,
   POLYGON_AMOY = 80002,
+  BASE_SEPOLIA = 84532,
 }

--- a/src/services/tokens/tokenService.ts
+++ b/src/services/tokens/tokenService.ts
@@ -6,13 +6,7 @@ interface Exchange {
   exchangeId: string
   assets: readonly `0x${string}`[]
 }
-import {
-  getContractAddress,
-  tryGetContractAddress,
-  ChainId,
-  RESERVE,
-  BIPOOLMANAGER,
-} from '../../core/constants'
+import { getContractAddress, tryGetContractAddress, ChainId, RESERVE, BIPOOLMANAGER } from '../../core/constants'
 import { retryOperation } from '../../utils'
 import { multicall } from '../../utils/multicall'
 import type { PublicClient } from 'viem'
@@ -20,12 +14,20 @@ import type { PublicClient } from 'viem'
 /**
  * Chains that use ReserveV2 (v3) instead of the legacy Reserve contract.
  */
-const RESERVE_V2_CHAINS: Set<number> = new Set([ChainId.MONAD_TESTNET, ChainId.MONAD, ChainId.POLYGON_AMOY])
+const RESERVE_V2_CHAINS: Set<number> = new Set([
+  ChainId.MONAD_TESTNET,
+  ChainId.MONAD,
+  ChainId.POLYGON_AMOY,
+  ChainId.BASE_SEPOLIA,
+])
 
 export class TokenService {
   private tokenMetadataCache = new Map<string, Pick<Token, 'name' | 'symbol' | 'decimals'>>()
 
-  constructor(private publicClient: PublicClient, private chainId: number) {}
+  constructor(
+    private publicClient: PublicClient,
+    private chainId: number
+  ) {}
 
   private isReserveV2(): boolean {
     return RESERVE_V2_CHAINS.has(this.chainId)
@@ -36,9 +38,7 @@ export class TokenService {
    * @param address - Token contract address
    * @returns Token metadata
    */
-  private async getTokenMetadata(
-    address: string
-  ): Promise<Pick<Token, 'name' | 'symbol' | 'decimals'>> {
+  private async getTokenMetadata(address: string): Promise<Pick<Token, 'name' | 'symbol' | 'decimals'>> {
     const cacheKey = address.toLowerCase()
     const cached = this.tokenMetadataCache.get(cacheKey)
     if (cached) {
@@ -76,7 +76,7 @@ export class TokenService {
 
     const multicallResults = await multicall(
       this.publicClient,
-      missing.flatMap(({ address }) => ([
+      missing.flatMap(({ address }) => [
         {
           address: address as `0x${string}`,
           abi: ERC20_ABI,
@@ -95,7 +95,7 @@ export class TokenService {
           functionName: 'decimals',
           args: [] as const,
         },
-      ])),
+      ]),
       { allowFailure: true }
     )
 
@@ -106,11 +106,7 @@ export class TokenService {
         const symbol = multicallResults[resultOffset + 1]
         const decimals = multicallResults[resultOffset + 2]
 
-        if (
-          name?.status === 'success' &&
-          symbol?.status === 'success' &&
-          decimals?.status === 'success'
-        ) {
+        if (name?.status === 'success' && symbol?.status === 'success' && decimals?.status === 'success') {
           return {
             name: name.result as string,
             symbol: symbol.result as string,
@@ -131,9 +127,7 @@ export class TokenService {
     return results
   }
 
-  private async readTokenMetadataWithRetry(
-    address: string
-  ): Promise<Pick<Token, 'name' | 'symbol' | 'decimals'>> {
+  private async readTokenMetadataWithRetry(address: string): Promise<Pick<Token, 'name' | 'symbol' | 'decimals'>> {
     const [name, symbol, decimals] = await Promise.all([
       retryOperation(() =>
         this.publicClient.readContract({
@@ -219,10 +213,7 @@ export class TokenService {
     return (totalSupply as bigint).toString()
   }
 
-  private async getCollateralStatusBatch(
-    reserveAddress: string,
-    addresses: string[]
-  ): Promise<boolean[]> {
+  private async getCollateralStatusBatch(reserveAddress: string, addresses: string[]): Promise<boolean[]> {
     if (addresses.length === 0) {
       return []
     }

--- a/src/utils/chainConfig.ts
+++ b/src/utils/chainConfig.ts
@@ -1,4 +1,4 @@
-import { celo, polygonAmoy, type Chain } from 'viem/chains'
+import { celo, polygonAmoy, baseSepolia, type Chain } from 'viem/chains'
 import { defineChain } from 'viem'
 import { ChainId } from '../core/constants/chainId'
 
@@ -98,6 +98,8 @@ export function getDefaultRpcUrl(chainId: number): string {
       return 'https://rpc.monad.xyz'
     case ChainId.POLYGON_AMOY:
       return 'https://polygon-amoy.drpc.org'
+    case ChainId.BASE_SEPOLIA:
+      return 'https://base-sepolia.drpc.org'
     default:
       throw new Error(`Unsupported chain ID: ${chainId}`)
   }
@@ -121,6 +123,8 @@ export function getChainConfig(chainId: number): Chain {
       return monad
     case ChainId.POLYGON_AMOY:
       return polygonAmoy
+    case ChainId.BASE_SEPOLIA:
+      return baseSepolia
     default:
       throw new Error(`Unsupported chain ID: ${chainId}`)
   }

--- a/tests/integration/services/liquidityFlow.test.ts
+++ b/tests/integration/services/liquidityFlow.test.ts
@@ -62,6 +62,11 @@ const CHAIN_CONFIGS: ChainTestConfig[] = [
     chainId: ChainId.POLYGON_AMOY,
     rpcEnvVar: 'POLYGON_AMOY_RPC_URL',
   },
+  {
+    name: 'Base Sepolia',
+    chainId: ChainId.BASE_SEPOLIA,
+    rpcEnvVar: 'BASE_SEPOLIA_RPC_URL',
+  },
 ]
 
 describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, rpcEnvVar }) => {
@@ -170,8 +175,8 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
       )
 
       // Liquidity should roughly double (allowing for rounding)
-      expect(quote2.liquidity).toBeGreaterThanOrEqual(quote1.liquidity * 19n / 10n) // At least 1.9x
-      expect(quote2.liquidity).toBeLessThanOrEqual(quote1.liquidity * 21n / 10n) // At most 2.1x
+      expect(quote2.liquidity).toBeGreaterThanOrEqual((quote1.liquidity * 19n) / 10n) // At least 1.9x
+      expect(quote2.liquidity).toBeLessThanOrEqual((quote1.liquidity * 21n) / 10n) // At most 2.1x
     })
   })
 
@@ -197,8 +202,8 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
       const quote2 = await liquidityService.quoteRemoveLiquidity(testPool.poolAddr, baseLiquidity * 2n)
 
       // Amounts should roughly double
-      expect(quote2.amount0).toBeGreaterThanOrEqual(quote1.amount0 * 19n / 10n)
-      expect(quote2.amount0).toBeLessThanOrEqual(quote1.amount0 * 21n / 10n)
+      expect(quote2.amount0).toBeGreaterThanOrEqual((quote1.amount0 * 19n) / 10n)
+      expect(quote2.amount0).toBeLessThanOrEqual((quote1.amount0 * 21n) / 10n)
     })
   })
 
@@ -219,7 +224,7 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
         tokenB: testPool.token1 as Address,
         amountB,
         recipient: recipient as Address,
-        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) }
+        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) },
       })
 
       expect(params).toBeDefined()
@@ -261,7 +266,7 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
         tokenB: testPool.token1 as Address,
         amountB,
         recipient: recipient as Address,
-        options: { slippageTolerance, deadline: deadlineFromMinutes(20) }
+        options: { slippageTolerance, deadline: deadlineFromMinutes(20) },
       })
 
       // Expected calculation: amountMin = amount * (1 - 0.005) = amount * 9950 / 10000
@@ -292,7 +297,7 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
         amountB,
         recipient: devAddress,
         owner: devAddress,
-        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) }
+        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) },
       })
 
       expect(transaction).toHaveProperty('approvalA')
@@ -332,7 +337,7 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
         poolAddress: testPool.poolAddr,
         liquidity,
         recipient: recipient as Address,
-        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) }
+        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) },
       })
 
       expect(params).toBeDefined()
@@ -365,7 +370,7 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
         liquidity,
         recipient: devAddress,
         owner: devAddress,
-        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) }
+        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) },
       })
 
       expect(transaction).toHaveProperty('approval')
@@ -421,9 +426,8 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
       const balance = await liquidityService.getLPTokenBalance(testPool.poolAddr, devAddress)
 
       // Verify share percentage calculation (basis-point precision: 0.01%)
-      const expectedSharePercent = balance.totalSupply > 0n
-        ? Number((balance.balance * 10000n) / balance.totalSupply) / 100
-        : 0
+      const expectedSharePercent =
+        balance.totalSupply > 0n ? Number((balance.balance * 10000n) / balance.totalSupply) / 100 : 0
 
       expect(balance.sharePercent).toBe(expectedSharePercent)
     })
@@ -439,13 +443,10 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
       const amountIn = 1000000000000000000n // 1 token
       const amountInSplit = 0.5 // 50/50 split
 
-      const quote = await liquidityService.quoteZapIn(
-        testPool.poolAddr,
-        tokenIn,
-        amountIn,
-        amountInSplit,
-        { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) }
-      )
+      const quote = await liquidityService.quoteZapIn(testPool.poolAddr, tokenIn, amountIn, amountInSplit, {
+        slippageTolerance: 0.5,
+        deadline: deadlineFromMinutes(20),
+      })
 
       expect(quote).toBeDefined()
       expect(quote).toHaveProperty('amountOutFromA')
@@ -470,7 +471,7 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
         amountIn,
         amountInSplit,
         recipient: recipient as Address,
-        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) }
+        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) },
       })
 
       expect(params).toBeDefined()
@@ -492,12 +493,10 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
       const tokenOut = testPool.token0 as Address
       const liquidity = 1000000000000000000n
 
-      const quote = await liquidityService.quoteZapOut(
-        testPool.poolAddr,
-        tokenOut,
-        liquidity,
-        { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) }
-      )
+      const quote = await liquidityService.quoteZapOut(testPool.poolAddr, tokenOut, liquidity, {
+        slippageTolerance: 0.5,
+        deadline: deadlineFromMinutes(20),
+      })
 
       expect(quote).toBeDefined()
       expect(quote).toHaveProperty('amountOutFromA')
@@ -520,7 +519,7 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
         tokenOut,
         liquidity,
         recipient: recipient as Address,
-        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) }
+        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) },
       })
 
       expect(params).toBeDefined()
@@ -554,13 +553,7 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
       const wrongToken = '0x9999000000000000000000000000000000000000' as Address
 
       await expect(
-        liquidityService.quoteAddLiquidity(
-          testPool.poolAddr,
-          testPool.token0 as Address,
-          1n,
-          wrongToken,
-          1n
-        )
+        liquidityService.quoteAddLiquidity(testPool.poolAddr, testPool.token0 as Address, 1n, wrongToken, 1n)
       ).rejects.toThrow(/don't match pool/)
     })
 
@@ -593,7 +586,7 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
         tokenB: testPool.token1 as Address,
         amountB: 2000000000000000000n,
         recipient,
-        options: { slippageTolerance: 0.5, deadline: customDeadline }
+        options: { slippageTolerance: 0.5, deadline: customDeadline },
       })
 
       expect(params.deadline).toBe(customDeadline)
@@ -612,7 +605,7 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
         tokenB: testPool.token1 as Address,
         amountB: amount,
         recipient,
-        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) } // 0.5%
+        options: { slippageTolerance: 0.5, deadline: deadlineFromMinutes(20) }, // 0.5%
       })
 
       const params2 = await liquidityService.buildAddLiquidityParams({
@@ -622,7 +615,7 @@ describe.each(CHAIN_CONFIGS)('Liquidity Flow Integration - $name', ({ chainId, r
         tokenB: testPool.token1 as Address,
         amountB: amount,
         recipient,
-        options: { slippageTolerance: 1.0, deadline: deadlineFromMinutes(20) } // 1.0%
+        options: { slippageTolerance: 1.0, deadline: deadlineFromMinutes(20) }, // 1.0%
       })
 
       // Higher slippage tolerance should result in lower minimums

--- a/tests/integration/services/poolDetails.test.ts
+++ b/tests/integration/services/poolDetails.test.ts
@@ -52,6 +52,11 @@ const CHAIN_CONFIGS: ChainTestConfig[] = [
     chainId: ChainId.POLYGON_AMOY,
     rpcEnvVar: 'POLYGON_AMOY_RPC_URL',
   },
+  {
+    name: 'Base Sepolia',
+    chainId: ChainId.BASE_SEPOLIA,
+    rpcEnvVar: 'BASE_SEPOLIA_RPC_URL',
+  },
 ]
 
 describe.each(CHAIN_CONFIGS)('PoolService.getPoolDetails() Integration - $name', ({ chainId, rpcEnvVar }) => {

--- a/tests/integration/services/poolRebalancePreview.test.ts
+++ b/tests/integration/services/poolRebalancePreview.test.ts
@@ -52,6 +52,11 @@ const CHAIN_CONFIGS: ChainTestConfig[] = [
     chainId: ChainId.POLYGON_AMOY,
     rpcEnvVar: 'POLYGON_AMOY_RPC_URL',
   },
+  {
+    name: 'Base Sepolia',
+    chainId: ChainId.BASE_SEPOLIA,
+    rpcEnvVar: 'BASE_SEPOLIA_RPC_URL',
+  },
 ]
 
 describe.each(CHAIN_CONFIGS)('PoolService.getPoolRebalancePreview() Integration - $name', ({ chainId, rpcEnvVar }) => {

--- a/tests/integration/services/routerSwapFlow.test.ts
+++ b/tests/integration/services/routerSwapFlow.test.ts
@@ -61,6 +61,11 @@ const CHAIN_CONFIGS: ChainTestConfig[] = [
     chainId: ChainId.POLYGON_AMOY,
     rpcEnvVar: 'POLYGON_AMOY_RPC_URL',
   },
+  {
+    name: 'Base Sepolia',
+    chainId: ChainId.BASE_SEPOLIA,
+    rpcEnvVar: 'BASE_SEPOLIA_RPC_URL',
+  },
 ]
 
 describe.each(CHAIN_CONFIGS)('Router Swap Flow Integration - $name', ({ chainId, rpcEnvVar }) => {
@@ -227,13 +232,10 @@ describe.each(CHAIN_CONFIGS)('Router Swap Flow Integration - $name', ({ chainId,
       const recipient = devAddress || '0x0000000000000000000000000000000000000001'
 
       const deadline = deadlineFromMinutes(20)
-      const swapDetails = await swapService.buildSwapParams(
-        tokenIn,
-        tokenOut,
-        amountIn,
-        recipient as Address,
-        { slippageTolerance: 0.5, deadline }
-      )
+      const swapDetails = await swapService.buildSwapParams(tokenIn, tokenOut, amountIn, recipient as Address, {
+        slippageTolerance: 0.5,
+        deadline,
+      })
 
       expect(swapDetails).toBeDefined()
       expect(swapDetails.params).toHaveProperty('to')
@@ -253,13 +255,10 @@ describe.each(CHAIN_CONFIGS)('Router Swap Flow Integration - $name', ({ chainId,
       const recipient = devAddress || '0x0000000000000000000000000000000000000001'
       const slippageTolerance = 0.5 // 0.5%
 
-      const swapDetails = await swapService.buildSwapParams(
-        tokenIn,
-        tokenOut,
-        amountIn,
-        recipient as Address,
-        { slippageTolerance, deadline: deadlineFromMinutes(20) }
-      )
+      const swapDetails = await swapService.buildSwapParams(tokenIn, tokenOut, amountIn, recipient as Address, {
+        slippageTolerance,
+        deadline: deadlineFromMinutes(20),
+      })
 
       // Verify slippage calculation: amountOutMin should be expectedAmountOut * (1 - slippage)
       const expectedMin = (swapDetails.expectedAmountOut * 9950n) / 10000n // 0.5% = 50 basis points
@@ -308,13 +307,10 @@ describe.each(CHAIN_CONFIGS)('Router Swap Flow Integration - $name', ({ chainId,
       const recipient = devAddress || '0x0000000000000000000000000000000000000001'
       const customDeadline = BigInt(Math.floor(Date.now() / 1000) + 60 * 60) // 1 hour
 
-      const swapDetails = await swapService.buildSwapParams(
-        tokenIn,
-        tokenOut,
-        amountIn,
-        recipient as Address,
-        { slippageTolerance: 0.5, deadline: customDeadline }
-      )
+      const swapDetails = await swapService.buildSwapParams(tokenIn, tokenOut, amountIn, recipient as Address, {
+        slippageTolerance: 0.5,
+        deadline: customDeadline,
+      })
 
       expect(swapDetails.deadline).toBe(customDeadline)
     })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new supported chain (`84532`) across constants, RPC selection, cached token/route data, and integration test coverage; risk is mainly misconfiguration (wrong addresses/routes) or ReserveV2 compatibility issues on the new network.
> 
> **Overview**
> Adds **Base Sepolia (chainId `84532`) support** end-to-end: network parsing/RPC defaults (incl. `BASE_SEPOLIA_RPC_URL`), `viem` chain config wiring, and new contract address mappings.
> 
> Updates auto-generated caches to include Base Sepolia tokens/routes (including new `EURC`) and refreshes some existing cached routes, and treats Base Sepolia as a `ReserveV2` chain in `TokenService`. Integration tests now run the swap/pool/liquidity flows against Base Sepolia, and the package version is bumped to `3.3.0-beta.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd336d57e15d67328e12f2c12fd8860c9892175a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->