### PR TITLE
docs: point agents to master context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Mento SDK Instructions
+
+For any protocol-level question that crosses beyond this SDK repo, first read
+the private `mento-master-context` router when the checkout is available:
+
+```text
+../mento-master-context/.agents/mento-context/README.md
+```
+
+This applies before broad repo searches for contracts, deployments, addresses,
+ABIs, live on-chain state, stable supply, reserve data, monitoring/data
+semantics, docs, the whitepaper, business model, or legal/risk framing. Load
+only the relevant master-context card(s), then return to this repo for SDK
+implementation details.
+
+This repo is source of truth for SDK behavior, not for published deployment
+addresses, generated ABIs, or current chain state. Resolve those through
+`deployments-v2` and live RPC as routed by master context. When answering,
+mention which master-context card you used or state that the checkout was
+unavailable.


### PR DESCRIPTION
## Summary
- Add a root AGENTS.md pointer to the private mento-master-context router.
- Keep this repo as source of truth for local implementation details while routing cross-protocol questions to the compact context index first.

## Validation
- git diff --check
- local autoreview helper: no deterministic findings
- commit/push hooks ran where configured

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or SDK logic changes.
> 
> **Overview**
> Adds root **`AGENTS.md`** so coding agents know how to work in this SDK repo versus cross-protocol Mento questions.
> 
> Agents are told to consult the private **`mento-master-context`** router (`../mento-master-context/.agents/mento-context/README.md`) before wide repo searches for deployments, ABIs, on-chain state, docs, and similar topics, then come back here for SDK implementation. The file also states this repo owns SDK behavior while **`deployments-v2`** and live RPC supply addresses and chain state, and that answers should cite which context card was used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd9eb497e5e4bbc2232af3ac08979449e03f0b6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->