### PR TITLE
feat: add EUROp/EURm pool to Polygon Amoy testnet

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -59,11 +59,14 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          # npm@12 (needed for trusted publishing) requires ^22.22.2.
+          node-version: '>=22.22.2 <23'
           registry-url: https://registry.npmjs.org
 
+      # Pinned rather than @latest: npm raises its engine floor over time, so a
+      # float silently breaks this job the moment it outpaces the Node above.
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@12
 
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -63,8 +63,6 @@ jobs:
           node-version: '>=22.22.2 <23'
           registry-url: https://registry.npmjs.org
 
-      # Pinned rather than @latest: npm raises its engine floor over time, so a
-      # float silently breaks this job the moment it outpaces the Node above.
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@12
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mento-protocol/mento-sdk",
   "description": "Official SDK for interacting with the Mento Protocol",
-  "version": "3.3.0-beta.1",
+  "version": "3.3.0-beta.2",
   "license": "MIT",
   "author": "Mento Labs",
   "keywords": [

--- a/src/cache/routes.ts
+++ b/src/cache/routes.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on 2026-05-06T12:40:03.576Z
+// Generated on 2026-07-14T18:29:17.848Z
 
 import type { RouteWithCost } from '../core/types'
 
@@ -8169,6 +8169,79 @@ export const cachedRoutes: Record<number, RouteWithCost[]> = {
           {
             "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
             "costPercent": 0.05
+          }
+        ]
+      }
+    },
+    {
+      "id": "EUROP-EURm",
+      "tokens": [
+        {
+          "address": "0x62A5E599c4f4bFA1024effFA15799a7a2Bb29dEC",
+          "symbol": "EUROP"
+        },
+        {
+          "address": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "symbol": "EURm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xB68536B95c0B415e300835ae9c6B62E362c244Ca",
+          "token0": "0x62A5E599c4f4bFA1024effFA15799a7a2Bb29dEC",
+          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.1,
+        "hops": [
+          {
+            "poolAddress": "0xB68536B95c0B415e300835ae9c6B62E362c244Ca",
+            "costPercent": 0.1
+          }
+        ]
+      }
+    },
+    {
+      "id": "EUROP-USDm",
+      "tokens": [
+        {
+          "address": "0x62A5E599c4f4bFA1024effFA15799a7a2Bb29dEC",
+          "symbol": "EUROP"
+        },
+        {
+          "address": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "symbol": "USDm"
+        }
+      ],
+      "path": [
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+          "token0": "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc",
+          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "poolType": "FPMM"
+        },
+        {
+          "factoryAddr": "0x353ED52bF8482027C0e0b9e3c0e5d96A9F680980",
+          "poolAddr": "0xB68536B95c0B415e300835ae9c6B62E362c244Ca",
+          "token0": "0x62A5E599c4f4bFA1024effFA15799a7a2Bb29dEC",
+          "token1": "0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0",
+          "poolType": "FPMM"
+        }
+      ],
+      "costData": {
+        "totalCostPercent": 0.14995,
+        "hops": [
+          {
+            "poolAddress": "0xD74728994135734968b03EFc03448394BaCb1e5f",
+            "costPercent": 0.05
+          },
+          {
+            "poolAddress": "0xB68536B95c0B415e300835ae9c6B62E362c244Ca",
+            "costPercent": 0.1
           }
         ]
       }

--- a/src/cache/tokens.ts
+++ b/src/cache/tokens.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Generated on 2026-05-06T12:39:32.137Z
+// Generated on 2026-07-14T18:28:33.128Z
 
 import type { Token } from '../core/types'
 
@@ -14,6 +14,7 @@ export enum TokenSymbol {
   CHFm = 'CHFm',
   COPm = 'COPm',
   EURC = 'EURC',
+  EUROP = 'EUROP',
   EURm = 'EURm',
   GBPm = 'GBPm',
   GHSm = 'GHSm',
@@ -273,6 +274,12 @@ export const cachedTokens: Record<number, readonly Token[]> = {
       symbol: TokenSymbol.EURm,
       name: 'Mento Euro',
       decimals: 18,
+    },
+    {
+      address: '0x62A5E599c4f4bFA1024effFA15799a7a2Bb29dEC',
+      symbol: TokenSymbol.EUROP,
+      name: 'Mento Mock EUROP',
+      decimals: 6,
     }
   ],
   // Chain 84532
@@ -461,6 +468,7 @@ export const TOKEN_ADDRESSES_BY_CHAIN: {
     [TokenSymbol.USDC]: '0xfbD2d6a7C3Cb4491647173D6eCb2a4473521cd66',
     [TokenSymbol.USDm]: '0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc',
     [TokenSymbol.EURm]: '0x666D0a83cDbf3eC62bDb624d9bFcD8F6345Ba7D0',
+    [TokenSymbol.EUROP]: '0x62A5E599c4f4bFA1024effFA15799a7a2Bb29dEC',
   },
   84532: {
     [TokenSymbol.EURC]: '0xe36C65cF840C16F45A0bd89628B89a9414DFda82',


### PR DESCRIPTION
### Description

A new FPMM pool (EUROp/EURm) was deployed on Polygon Amoy. The SDK's static caches are generated from chain, so until they are regenerated the new pool and its token are invisible to consumers: `EUROP` was missing from `TokenSymbol` / `cachedTokens`, and no routes touching it existed in `cachedRoutes`.

This regenerates both caches (`pnpm cacheTokens`, `pnpm cacheRoutes`) so Polygon Amoy (80002) now includes:

- **Token:** `EUROP` — `0x62A5E599c4f4bFA1024effFA15799a7a2Bb29dEC`, **6 decimals** (note: the on-chain symbol is upper-case `EUROP`, not `EUROp`)
- **Routes:** `EUROP-EURm` (direct) and `EUROP-USDm` (2-hop via EURm)

Amoy goes from 3 → 4 tokens and 3 → 5 routes. No source changes were needed — pool discovery already reads the FPMM factory on chain, so the new pool is picked up automatically.

Version is bumped to `3.3.0-beta.2` so the frontend can consume the updated caches.

### Other changes

**Unbreaks the npm publish workflow.** The publish job pinned Node 20 and then ran `npm install -g npm@latest`. npm@12 now requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, so the step failed with `EBADENGINE` and no release could go out — this blocks publishing entirely, independent of this PR. Fixed by raising the publish job to `>=22.22.2 <23` (the floor npm@12 needs for trusted publishing; Node 22 is already in the CI matrix) and pinning `npm@12` rather than floating on `@latest`, so the next npm engine bump can't silently break publishing again.

The cache generators rewrite the whole file from only the chains they process, so both scripts were run against **all** chains (a single-chain run would drop the others). The regenerated output was diffed per chain to confirm the only change is the two new Amoy routes and the new token — every other chain is byte-identical.

One thing worth calling out separately: the route generator is not fully deterministic. Re-running it swapped four equal-cost 2-hop routes on Monad testnet (`AUSD-EURm`/`JPYm-USDT0` out, `AUSD-JPYm`/`USDC-USDT0` in) with the route count unchanged at 13, which looks like an unstable tie-break between equal-cost paths. That churn is unrelated to this change and was reverted to keep this diff purely additive; the affected pairs remain tradable via the USDm hub. Probably worth a follow-up look at the tie-break ordering.

### Tested

- `pnpm cacheTokens` and `pnpm cacheRoutes` run against all 6 chains, 0 errors.
- Verified on chain that the SDK discovers the new pool: `RouteService.getDirectRoutes()` on 80002 returns the EUROP/EURm pool at `0xB68536B95c0B415e300835ae9c6B62E362c244Ca`. The pool reports `oraclePrice = 1`, confirming it is a EUR/EUR pair.
- `pnpm test` — 446 unit tests pass.
- `pnpm lint` and `tsc --noEmit` clean.
- Built `dist` and confirmed the published surface is correct:
  - `cachedTokens[80002]` → `USDC:6, USDm:18, EURm:18, EUROP:6`
  - `getTokenAddress(80002, TokenSymbol.EUROP)` → `0x62A5E599c4f4bFA1024effFA15799a7a2Bb29dEC`
  - `getCachedRoutes(80002)` → `USDC-USDm, EURm-USDm, EURm-USDC, EUROP-EURm, EUROP-USDm`

### Related issues

N/A

### Backwards compatibility

Backwards compatible. The change is purely additive: a new `TokenSymbol.EUROP` enum member, one new token entry, and two new routes on Polygon Amoy. No existing token, route, or exported symbol is modified or removed.

### Documentation

None required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive testnet cache data and CI-only publish job changes; no runtime logic or security-sensitive code paths modified.
> 
> **Overview**
> Bumps **`@mento-protocol/mento-sdk`** to **`3.3.0-beta.2`** and refreshes auto-generated **`cachedTokens`** / **`cachedRoutes`** so Polygon Amoy (**80002**) exposes **`EUROP`** (6 decimals) plus **`EUROP-EURm`** and **`EUROP-USDm`** swap routes.
> 
> Repairs the **npm publish** job: Node moves from **20** to **`>=22.22.2 <23`** and global npm is pinned to **`npm@12`** instead of **`@latest`**, matching npm trusted-publishing engine requirements and avoiding future silent breaks from floating latest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0735b33b7b73cef7e42b9316c306cfee281d8032. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

