### PR TITLE
chore(ci): exclude major updates from dev-deps dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
       dev-deps:
         applies-to: version-updates
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
  
     # Commit message prefix for easy filtering
     commit-message:


### PR DESCRIPTION
## Summary

The `dev-deps` dependabot group had no `update-types` filter, so major dev-dependency bumps were folded into the monthly grouped PR alongside routine minors/patches. This is how TypeScript 5.9.3 → 7.0.2 ended up breaking CI in #187 and again in #188, hidden inside an otherwise-routine `chore(deps-dev)` PR.

This restricts the `dev-deps` group to `minor` + `patch`, matching the existing `production-deps` group policy. Majors (TypeScript 7, @types/node 26, size-limit 13, …) will now arrive as **individual PRs** that can be reviewed — or deliberately deferred — one at a time, which fits our supply-chain review posture.

## Notes

- A per-dependency ignore for typescript 7.x is also registered via `@dependabot ignore typescript major version` (see #187); it's redundant once this merges but harmless.
- After this merges, `@dependabot recreate` on the open dev-deps group PR will rebuild it without the majors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Dependabot configuration change with no runtime or application code impact.
> 
> **Overview**
> Aligns the **`dev-deps`** Dependabot group with **`production-deps`** by adding **`update-types: minor` + `patch`**, so routine monthly grouped dev-dependency PRs no longer bundle **major** bumps.
> 
> Major dev updates (e.g. TypeScript 7, large `@types/*` jumps) should now land as **separate PRs** for targeted review instead of breaking CI inside a bulk `chore(deps-dev)` roll-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f3a7942b341c5508666dd701a73458f0a5b7c9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->